### PR TITLE
Simplify update of relative paths in verification

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -82,9 +82,12 @@ function App(props: {
               props.verification
             );
 
-            verification.updatePathVersionOnStateChange(
-              props.verification.instancesPathVersioning,
-              pathInEnvironment
+            verification.updateRelativePathsOnStateChange(
+              props.state.environment,
+              pathInEnvironment,
+              value,
+              prevValue,
+              props.verification.instancesPathVersioning
             );
           }
         }


### PR DESCRIPTION
We refactored the changes of relative paths out of `model` module, and moved all the logic into the `verification` module. This makes the reasoning about the notifications much easier as the changes are tracked only in the single module, `verification`.