### PR TITLE
Debounce changes in errors

### DIFF
--- a/src/components/Errors.tsx
+++ b/src/components/Errors.tsx
@@ -2,7 +2,7 @@ import * as aas from "@aas-core-works/aas-core3.0rc02-typescript";
 import * as React from "react";
 import * as valtio from "valtio";
 
-import * as model from '../model'
+import * as hooks from "./hooks"
 import * as verification from '../verification'
 
 function sortErrors(
@@ -59,6 +59,16 @@ export function Errors(
     props.verification.errorMap.versioning
   );
 
+  const debouncedPathVersion = hooks.useDebounce(
+    snapInstancesPathVersioning.version,
+    200
+  );
+
+  const debouncedErrorVersion = hooks.useDebounce(
+    snapErrorVersioning.version,
+    200
+  );
+
   React.useEffect(
     () => {
       const errors = sortErrors(props.verification.errorMap.errors());
@@ -69,8 +79,8 @@ export function Errors(
       }
     },
     [
-      snapInstancesPathVersioning.version,
-      snapErrorVersioning.version
+      debouncedPathVersion,
+      debouncedErrorVersion
     ]
   )
 

--- a/src/components/hooks/index.ts
+++ b/src/components/hooks/index.ts
@@ -1,0 +1,1 @@
+export { useDebounce } from "./useDebounce";

--- a/src/components/hooks/useDebounce.ts
+++ b/src/components/hooks/useDebounce.ts
@@ -1,0 +1,23 @@
+import * as React from "react";
+
+// From: https://usehooks.com/useDebounce/
+export function useDebounce<T>(value: T, delay: number) {
+  const [debouncedValue, setDebouncedValue] = React.useState(value);
+
+  React.useEffect(
+    () => {
+      // Update debounced value after delay
+      const handler = setTimeout(() => {
+        setDebouncedValue(value);
+      }, delay);
+
+      return () => {
+        clearTimeout(handler);
+      };
+    },
+    // Only re-call effect if value or delay changes
+    [value, delay]
+  );
+
+  return debouncedValue;
+}

--- a/src/components/widgets/BytesContainer.tsx
+++ b/src/components/widgets/BytesContainer.tsx
@@ -2,29 +2,7 @@ import * as aas from "@aas-core-works/aas-core3.0rc02-typescript";
 import * as React from "react";
 
 import * as  mimetype from "../../mimetype";
-
-// From: https://usehooks.com/useDebounce/
-function useDebounce<T>(value: T, delay: number) {
-  const [debouncedValue, setDebouncedValue] = React.useState(value);
-
-  React.useEffect(
-    () => {
-      // Update debounced value after delay
-      const handler = setTimeout(() => {
-        setDebouncedValue(value);
-      }, delay);
-
-      return () => {
-        clearTimeout(handler);
-      };
-    },
-    // Only re-call effect if value or delay changes
-    [value, delay]
-  );
-
-  return debouncedValue;
-}
-
+import * as hooks from "../hooks"
 
 export function BytesContainer(
   props: {
@@ -95,7 +73,7 @@ export function BytesContainer(
     renderContent()
   );
 
-  const debouncedContentType = useDebounce(props.contentType, 200);
+  const debouncedContentType = hooks.useDebounce(props.contentType, 200);
 
   React.useEffect(
     () => {

--- a/src/components/widgets/index.ts
+++ b/src/components/widgets/index.ts
@@ -3,3 +3,4 @@ export { OkScreen } from "./OkScreen";
 export { OkCancelScreen } from "./OkCancelScreen";
 export { SplashScreen } from "./SplashScreen";
 export { TextAreaAutoResized } from "./TextAreaAutoResized";
+export { useDebounce } from "../hooks/useDebounce";


### PR DESCRIPTION
We debounce re-rendering of the errors so that we spare a few cycles if the user is producing too many changes.