### PR TITLE
Fix bubbling up for verification

### DIFF
--- a/src/model.ts
+++ b/src/model.ts
@@ -1,6 +1,5 @@
 import * as aas from "@aas-core-works/aas-core3.0rc02-typescript";
 
-import * as debugconf from "./debugconf";
 import * as emptory from "./emptory.generated";
 import * as enhancing from "./enhancing.generated";
 


### PR DESCRIPTION
We had an error in the logic for bubbling up an instance for verification. Namely, the instance and its *descendants* were removed from the error map, whereas we should have removed its *antecedents*, as they were going to be included in the (re-)verification.

This patch fixes the issue.