### PR TITLE
Move errors into model

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,8 +6,7 @@ import * as model from "./model"
 import * as verification from "./verification"
 
 import './App.css'
-import * as enhancing from "./enhancing.generated";
-import * as emptory from "./emptory.generated";
+import * as debugconf from "./debugconf";
 
 function useUnload<FuncT extends (event: BeforeUnloadEvent) => any>(
   func: FuncT
@@ -32,6 +31,10 @@ function App(props: {
   const snapState =
     valtio.useSnapshot(props.state) as Readonly<typeof props.state>;
 
+  const snapErrorMapVersioning = valtio.useSnapshot(
+    props.verification.errorMap.versioning
+  );
+
   useUnload((event) => {
     event.preventDefault();
   })
@@ -50,6 +53,15 @@ function App(props: {
     },
     [props.verification]
   )
+
+  if (debugconf.DEBUG_WITH_INVARIANTS) {
+    React.useEffect(() => {
+      props.verification.errorMap.assertErrorCountCorrect(
+        snapState.environment
+      );
+    },
+      [snapErrorMapVersioning, snapState])
+  }
 
   React.useEffect(() => {
       // noinspection UnnecessaryLocalVariableJS
@@ -113,7 +125,7 @@ function App(props: {
 
       <components.Errors
         verification={props.verification}
-        snapEnvironment={snapState.environment}
+        environment={props.state.environment}
       />
     </div>
   )

--- a/src/model.ts
+++ b/src/model.ts
@@ -2,6 +2,7 @@ import * as aas from "@aas-core-works/aas-core3.0rc02-typescript";
 
 import * as emptory from "./emptory.generated";
 import * as enhancing from "./enhancing.generated";
+import { TimestampedError, VersionedSet } from "./enhancing.generated";
 
 /**
  * Provide model of the app.
@@ -228,6 +229,36 @@ export function moveInContainer<ClassT extends aas.types.Class>(
   newContainer[sourceIndex] = tmp;
 
   return newContainer;
+}
+
+export function getErrorSet(
+  instance: aas.types.Class
+): VersionedSet<TimestampedError> {
+  const enhanced = enhancing.asEnhanced(instance);
+  if (enhanced === null) {
+    console.error(
+      "Expected the instance to have been enhanced, but it was not",
+      instance
+    );
+    throw new Error("Assertion violated");
+  }
+
+  return enhanced._aasCoreEditorEnhancement.errors;
+}
+
+export function getDescendantsWithErrors(
+  instance: aas.types.Class
+): VersionedSet<aas.types.Class> {
+  const enhanced = enhancing.asEnhanced(instance);
+  if (enhanced === null) {
+    console.error(
+      "Expected the instance to have been enhanced, but it was not",
+      instance
+    );
+    throw new Error("Assertion violated");
+  }
+
+  return enhanced._aasCoreEditorEnhancement.descendantsWithErrors;
 }
 
 export const INITIAL_FILENAME = "untitled.json";


### PR DESCRIPTION
We move the errors into the model to allow for displaying them locally.