### PR TITLE
Show localized errors

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -3,15 +3,24 @@
   "parser": "@typescript-eslint/parser",
   "plugins": [
     "@typescript-eslint",
-    "prettier"
+    "prettier",
+    "react"
   ],
   "extends": [
     "eslint:recommended",
     "plugin:@typescript-eslint/eslint-recommended",
     "plugin:@typescript-eslint/recommended",
-    "prettier"
+    "prettier",
+    "plugin:react/recommended"
   ],
   "rules": {
-    "prettier/prettier": ["error"]
+    "prettier/prettier": [
+      "error"
+    ]
+  },
+  settings: {
+    react: {
+      version: 'detect'
+    }
   }
 }

--- a/codegen/codegen/generate_enhancing.py
+++ b/codegen/codegen/generate_enhancing.py
@@ -17,6 +17,7 @@ from aas_core_codegen.typescript.common import (
     INDENT as I,
     INDENT2 as II,
     INDENT3 as III,
+    INDENT4 as IIII
 )
 
 import codegen.common
@@ -209,48 +210,73 @@ export class TimestampedError {{
 
 {II}return result;
 {I}}}
+
+{I}relativePathFromInstanceAsString(): string {{
+{II}if (this.relativePathFromInstance.length === 0) {{
+{III}return "";
+{II}}}
+
+{II}// NOTE (2023-02-10):
+{II}// See: https://stackoverflow.com/questions/16696632/most-efficient-way-to-concatenate-strings-in-javascript
+{II}// for string concatenation.
+{II}let result = "";
+
+{II}for (const segment of this.relativePathFromInstance) {{
+{III}if (typeof segment === "string") {{
+{IIII}result += `.${{segment}}`;
+{III}}} else {{
+{IIII}result += `[${{segment}}]`;
+{III}}}
+{II}}}
+
+{II}return result;
+{I}}}
 }}"""
         ),
         Stripped(
             f"""\
 export class VersionedSet<T> {{
-{I}private readonly content = new Set<T>();
-{I}private readonly versioning = valtio.proxy({{ version: 0 }});
+{I}private readonly _content = new Set<T>();
+{I}private readonly _versioning = valtio.proxy({{ version: 0 }});
 
 {I}*[Symbol.iterator]() {{
-{II}yield* this.content;
+{II}yield* this._content;
 {I}}}
 
 {I}add(item: T) {{
 {II}let bumpVersion = false;
-{II}if (!this.content.has(item)) {{
-{III}this.content.add(item);
+{II}if (!this._content.has(item)) {{
+{III}this._content.add(item);
 {III}bumpVersion = true;
 {II}}}
 
 {II}if (bumpVersion) {{
-{III}this.versioning.version++;
+{III}this._versioning.version++;
 {II}}}
 {I}}}
 {I}
 {I}delete(item: T) {{
-{II}const bumpVersion = this.content.delete(item);
+{II}const bumpVersion = this._content.delete(item);
 {II}if (bumpVersion) {{
-{III}this.versioning.version++;
+{III}this._versioning.version++;
 {II}}}
 {I}}}
 {I}
 {I}clear() {{
-{II}if (this.content.size === 0) {{
+{II}if (this._content.size === 0) {{
 {III}return;
 {II}}}
 
-{II}this.content.clear();
-{II}this.versioning.version++;
+{II}this._content.clear();
+{II}this._versioning.version++;
 {I}}}
 
 {I}public get size() {{
-{II}return this.content.size;
+{II}return this._content.size;
+{I}}}
+
+{I}public get versioning() {{
+{II}return this._versioning;
 {I}}}
 }}"""
         ),

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "eslint": "^8.32.0",
         "eslint-config-prettier": "^8.6.0",
         "eslint-plugin-prettier": "^4.2.1",
+        "eslint-plugin-react": "^7.32.2",
         "prettier": "^2.8.3",
         "typescript": "^4.9.3",
         "vite": "^4.0.0",
@@ -1306,6 +1307,25 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true
     },
+    "node_modules/array-includes": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.6.tgz",
+      "integrity": "sha512-sgTbLvL6cNnw24FnbaDyjmvddQ2ML8arZsgaJhoABMoplz/4QRhtrYS+alr1BUM1Bwp6dhx8vVCBSLG+StwOFw==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.20.4",
+        "get-intrinsic": "^1.1.3",
+        "is-string": "^1.0.7"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/array-union": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
@@ -1313,6 +1333,49 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/array.prototype.flatmap": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.3.1.tgz",
+      "integrity": "sha512-8UGn9O1FDVvMNB0UlLv4voxRMze7+FpHyF5mSMRjWHUMlpoDViniy05870VlxhfgTnLbpuwTzvD76MTtWxB/mQ==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.20.4",
+        "es-shim-unscopables": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array.prototype.tosorted": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array.prototype.tosorted/-/array.prototype.tosorted-1.1.1.tgz",
+      "integrity": "sha512-pZYPXPRl2PqWcsUs6LOMn+1f1532nEoPTYowBtqLwAW+W8vSVhkIGnmOX1t/UQjD6YGI0vcD2B1U7ZFGQH9jnQ==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.20.4",
+        "es-shim-unscopables": "^1.0.0",
+        "get-intrinsic": "^1.1.3"
+      }
+    },
+    "node_modules/available-typed-arrays": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
+      "integrity": "sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/balanced-match": {
@@ -1369,6 +1432,19 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/call-bind": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+      "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+      "dev": true,
+      "dependencies": {
+        "function-bind": "^1.1.1",
+        "get-intrinsic": "^1.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/callsites": {
@@ -1480,6 +1556,22 @@
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true
     },
+    "node_modules/define-properties": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.0.tgz",
+      "integrity": "sha512-xvqAVKGfT1+UAvPwKTVw/njhdQ8ZhXK4lI0bCIuCMrp2up9nPnaDftrLtmpTazqd1o+UY4zgzU+avtMbDP+ldA==",
+      "dev": true,
+      "dependencies": {
+        "has-property-descriptors": "^1.0.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/dir-glob": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
@@ -1509,6 +1601,93 @@
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.284.tgz",
       "integrity": "sha512-M8WEXFuKXMYMVr45fo8mq0wUrrJHheiKZf6BArTKk9ZBYCKJEOU5H8cdWgDT+qCVZf7Na4lVUaZsA+h6uA9+PA==",
       "dev": true
+    },
+    "node_modules/es-abstract": {
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.21.1.tgz",
+      "integrity": "sha512-QudMsPOz86xYz/1dG1OuGBKOELjCh99IIWHLzy5znUB6j8xG2yMA7bfTV86VSqKF+Y/H08vQPR+9jyXpuC6hfg==",
+      "dev": true,
+      "dependencies": {
+        "available-typed-arrays": "^1.0.5",
+        "call-bind": "^1.0.2",
+        "es-set-tostringtag": "^2.0.1",
+        "es-to-primitive": "^1.2.1",
+        "function-bind": "^1.1.1",
+        "function.prototype.name": "^1.1.5",
+        "get-intrinsic": "^1.1.3",
+        "get-symbol-description": "^1.0.0",
+        "globalthis": "^1.0.3",
+        "gopd": "^1.0.1",
+        "has": "^1.0.3",
+        "has-property-descriptors": "^1.0.0",
+        "has-proto": "^1.0.1",
+        "has-symbols": "^1.0.3",
+        "internal-slot": "^1.0.4",
+        "is-array-buffer": "^3.0.1",
+        "is-callable": "^1.2.7",
+        "is-negative-zero": "^2.0.2",
+        "is-regex": "^1.1.4",
+        "is-shared-array-buffer": "^1.0.2",
+        "is-string": "^1.0.7",
+        "is-typed-array": "^1.1.10",
+        "is-weakref": "^1.0.2",
+        "object-inspect": "^1.12.2",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.4",
+        "regexp.prototype.flags": "^1.4.3",
+        "safe-regex-test": "^1.0.0",
+        "string.prototype.trimend": "^1.0.6",
+        "string.prototype.trimstart": "^1.0.6",
+        "typed-array-length": "^1.0.4",
+        "unbox-primitive": "^1.0.2",
+        "which-typed-array": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.0.1.tgz",
+      "integrity": "sha512-g3OMbtlwY3QewlqAiMLI47KywjWZoEytKr8pf6iTC8uJq5bIAH52Z9pnQ8pVL6whrCto53JZDuUIsifGeLorTg==",
+      "dev": true,
+      "dependencies": {
+        "get-intrinsic": "^1.1.3",
+        "has": "^1.0.3",
+        "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-shim-unscopables": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/es-shim-unscopables/-/es-shim-unscopables-1.0.0.tgz",
+      "integrity": "sha512-Jm6GPcCdC30eMLbZ2x8z2WuRwAws3zTBBKuusffYVUrNj/GVSUAZ+xKMaUpfNDR5IbyNA5LJbaecoUVbmUcB1w==",
+      "dev": true,
+      "dependencies": {
+        "has": "^1.0.3"
+      }
+    },
+    "node_modules/es-to-primitive": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
+      "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
+      "dev": true,
+      "dependencies": {
+        "is-callable": "^1.1.4",
+        "is-date-object": "^1.0.1",
+        "is-symbol": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/esbuild": {
       "version": "0.16.16",
@@ -1652,6 +1831,73 @@
         "eslint-config-prettier": {
           "optional": true
         }
+      }
+    },
+    "node_modules/eslint-plugin-react": {
+      "version": "7.32.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.32.2.tgz",
+      "integrity": "sha512-t2fBMa+XzonrrNkyVirzKlvn5RXzzPwRHtMvLAtVZrt8oxgnTQaYbU6SXTOO1mwQgp1y5+toMSKInnzGr0Knqg==",
+      "dev": true,
+      "dependencies": {
+        "array-includes": "^3.1.6",
+        "array.prototype.flatmap": "^1.3.1",
+        "array.prototype.tosorted": "^1.1.1",
+        "doctrine": "^2.1.0",
+        "estraverse": "^5.3.0",
+        "jsx-ast-utils": "^2.4.1 || ^3.0.0",
+        "minimatch": "^3.1.2",
+        "object.entries": "^1.1.6",
+        "object.fromentries": "^2.0.6",
+        "object.hasown": "^1.1.2",
+        "object.values": "^1.1.6",
+        "prop-types": "^15.8.1",
+        "resolve": "^2.0.0-next.4",
+        "semver": "^6.3.0",
+        "string.prototype.matchall": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "peerDependencies": {
+        "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8"
+      }
+    },
+    "node_modules/eslint-plugin-react/node_modules/doctrine": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+      "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+      "dev": true,
+      "dependencies": {
+        "esutils": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/eslint-plugin-react/node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/eslint-plugin-react/node_modules/resolve": {
+      "version": "2.0.0-next.4",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.4.tgz",
+      "integrity": "sha512-iMDbmAWtfU+MHpxt/I5iWI7cY6YVEZUQ3MBgPQ++XD1PELuJHIl82xBmObyP2KyQmkNB2dsqF7seoQQiAn5yDQ==",
+      "dev": true,
+      "dependencies": {
+        "is-core-module": "^2.9.0",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/eslint-scope": {
@@ -2019,6 +2265,15 @@
       "integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==",
       "dev": true
     },
+    "node_modules/for-each": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
+      "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
+      "dev": true,
+      "dependencies": {
+        "is-callable": "^1.1.3"
+      }
+    },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -2045,6 +2300,33 @@
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
       "dev": true
     },
+    "node_modules/function.prototype.name": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.5.tgz",
+      "integrity": "sha512-uN7m/BzVKQnCUF/iW8jYea67v++2u7m5UgENbHRtdDVclOUP+FMPlCNdmk0h/ysGyo2tavMJEDqJAkJdRa1vMA==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.19.0",
+        "functions-have-names": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/functions-have-names": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
+      "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -2052,6 +2334,36 @@
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.0.tgz",
+      "integrity": "sha512-L049y6nFOuom5wGyRc3/gdTLO94dySVKRACj1RmJZBQXlbTMhtNIgkWkUHq+jYmZvKf14EW1EoJnnjbmoHij0Q==",
+      "dev": true,
+      "dependencies": {
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "has-symbols": "^1.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-symbol-description": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.0.0.tgz",
+      "integrity": "sha512-2EmdH1YvIQiZpltCNgkuiUnyukzxM/R6NDJX31Ke3BG1Nq5b0S2PhX59UKi9vZpPDQVdqn+1IcaAwnzTT5vCjw==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "get-intrinsic": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/glob": {
@@ -2095,6 +2407,21 @@
         "node": ">=4"
       }
     },
+    "node_modules/globalthis": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.3.tgz",
+      "integrity": "sha512-sFdI5LyBiNTHjRd7cGPWapiHWMOXKyuBNX/cWJ3NfzrZQVa8GI/8cofCl74AOVqq9W5kNmguTIzJ/1s2gyI9wA==",
+      "dev": true,
+      "dependencies": {
+        "define-properties": "^1.1.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/globby": {
       "version": "11.1.0",
       "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
@@ -2115,6 +2442,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/gopd": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
+      "integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
+      "dev": true,
+      "dependencies": {
+        "get-intrinsic": "^1.1.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/grapheme-splitter": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz",
@@ -2133,6 +2472,15 @@
         "node": ">= 0.4.0"
       }
     },
+    "node_modules/has-bigints": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
+      "integrity": "sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
@@ -2140,6 +2488,57 @@
       "dev": true,
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.0.tgz",
+      "integrity": "sha512-62DVLZGoiEBDHQyqG4w9xCuZ7eJEwNmJRWw2VY84Oedb7WFcA27fiEVe8oUQx9hAUJ4ekurquucTGwsyO1XGdQ==",
+      "dev": true,
+      "dependencies": {
+        "get-intrinsic": "^1.1.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.1.tgz",
+      "integrity": "sha512-7qE+iP+O+bgF9clE5+UoBFzE65mlBiVj3tKCrlNQ0Ogwm0BjpT/gK4SlLYDMybDh5I3TCTKnPPa0oMG7JDYrhg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
+      "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.0.tgz",
+      "integrity": "sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==",
+      "dev": true,
+      "dependencies": {
+        "has-symbols": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/ignore": {
@@ -2192,6 +2591,74 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true
     },
+    "node_modules/internal-slot": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.5.tgz",
+      "integrity": "sha512-Y+R5hJrzs52QCG2laLn4udYVnxsfny9CpOhNhUvk/SSSVyF6T27FzRbF0sroPidSu3X8oEAkOn2K804mjpt6UQ==",
+      "dev": true,
+      "dependencies": {
+        "get-intrinsic": "^1.2.0",
+        "has": "^1.0.3",
+        "side-channel": "^1.0.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/is-array-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.1.tgz",
+      "integrity": "sha512-ASfLknmY8Xa2XtB4wmbz13Wu202baeA18cJBCeCy0wXUHZF0IPyVEXqKEcd+t2fNSLLL1vC6k7lxZEojNbISXQ==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "get-intrinsic": "^1.1.3",
+        "is-typed-array": "^1.1.10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-bigint": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.4.tgz",
+      "integrity": "sha512-zB9CruMamjym81i2JZ3UMn54PKGsQzsJeo6xvN3HJJ4CAsQNB6iRutp2To77OfCNuoxspsIhzaPoO1zyCEhFOg==",
+      "dev": true,
+      "dependencies": {
+        "has-bigints": "^1.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-boolean-object": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.2.tgz",
+      "integrity": "sha512-gDYaKHJmnj4aWxyj6YHyXVpdQawtVLHU5cb+eztPGczf6cjuTdwve5ZIEfgXqH4e57An1D1AKf8CZ3kYrQRqYA==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-callable": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+      "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-core-module": {
       "version": "2.11.0",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.11.0.tgz",
@@ -2199,6 +2666,21 @@
       "dev": true,
       "dependencies": {
         "has": "^1.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-date-object": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.5.tgz",
+      "integrity": "sha512-9YQaSxsAiSwcvS33MBk3wTCVnWK+HhF8VZR2jRxehM16QcVOdHqPn4VPHmRK4lSr38n9JriurInLcP90xsYNfQ==",
+      "dev": true,
+      "dependencies": {
+        "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -2225,6 +2707,18 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-negative-zero": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.2.tgz",
+      "integrity": "sha512-dqJvarLawXsFbNDeJW7zAz8ItJ9cd28YufuuFzh0G8pNHjJMnY08Dv7sYX2uF5UpQOwieAeOExEYAWWfu7ZZUA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -2234,6 +2728,21 @@
         "node": ">=0.12.0"
       }
     },
+    "node_modules/is-number-object": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.7.tgz",
+      "integrity": "sha512-k1U0IRzLMo7ZlYIfzRu23Oh6MiIFasgpb9X76eqfFZAqwH44UI4KTBvBYIZ1dSL9ZzChTB9ShHfLkR4pdW5krQ==",
+      "dev": true,
+      "dependencies": {
+        "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-path-inside": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
@@ -2241,6 +2750,95 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/is-regex": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
+      "integrity": "sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-shared-array-buffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.2.tgz",
+      "integrity": "sha512-sqN2UDu1/0y6uvXyStCOzyhAjCSlHceFoMKJW8W9EU9cvic/QdsZ0kEU93HEy3IUEFZIiH/3w+AH/UQbPHNdhA==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-string": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.7.tgz",
+      "integrity": "sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==",
+      "dev": true,
+      "dependencies": {
+        "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-symbol": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.4.tgz",
+      "integrity": "sha512-C/CPBqKWnvdcxqIARxyOh4v1UUEOCHpgDa0WYgpKDFMszcrPcffg5uhwSgPCLD2WWxmq6isisz87tzT01tuGhg==",
+      "dev": true,
+      "dependencies": {
+        "has-symbols": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-typed-array": {
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.10.tgz",
+      "integrity": "sha512-PJqgEHiWZvMpaFZ3uTc8kHPM4+4ADTlDniuQL7cU/UDA0Ql7F70yGfHph3cLNe+c9toaigv+DFzTJKhc2CtO6A==",
+      "dev": true,
+      "dependencies": {
+        "available-typed-arrays": "^1.0.5",
+        "call-bind": "^1.0.2",
+        "for-each": "^0.3.3",
+        "gopd": "^1.0.1",
+        "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakref": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.2.tgz",
+      "integrity": "sha512-qctsuLZmIQ0+vSSMfoVvyFe2+GSEvnmZ2ezTup1SBse9+twCCeial6EEi3Nc2KFcf6+qz2FBPnjXsk8xhKSaPQ==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/isexe": {
@@ -2310,6 +2908,19 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/jsx-ast-utils": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.3.tgz",
+      "integrity": "sha512-fYQHZTZ8jSfmWZ0iyzfwiU4WDX4HpHbMCZ3gPlWYiCl3BoeOTsqKBqnTVfH2rYT7eP5c3sVbeSPHnnJOaTrWiw==",
+      "dev": true,
+      "dependencies": {
+        "array-includes": "^3.1.5",
+        "object.assign": "^4.1.3"
+      },
+      "engines": {
+        "node": ">=4.0"
       }
     },
     "node_modules/levn": {
@@ -2447,6 +3058,112 @@
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.8.tgz",
       "integrity": "sha512-dFSmB8fFHEH/s81Xi+Y/15DQY6VHW81nXRj86EMSL3lmuTmK1e+aT4wrFCkTbm+gSwkw4KpX+rT/pMM2c1mF+A==",
       "dev": true
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.12.3",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.3.tgz",
+      "integrity": "sha512-geUvdk7c+eizMNUDkRpW1wJwgfOiOeHbxBR/hLXK1aT6zmVSO0jsQcs7fj6MGw89jC/cjGfLcNOrtMYtGqm81g==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/object.assign": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.4.tgz",
+      "integrity": "sha512-1mxKf0e58bvyjSCtKYY4sRe9itRk3PJpquJOjeIkz885CczcI4IvJJDLPS72oowuSh+pBxUFROpX+TU++hxhZQ==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.4",
+        "has-symbols": "^1.0.3",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object.entries": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.6.tgz",
+      "integrity": "sha512-leTPzo4Zvg3pmbQ3rDK69Rl8GQvIqMWubrkxONG9/ojtFE2rD9fjMKfSI5BxW3osRH1m6VdzmqK8oAY9aT4x5w==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.20.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/object.fromentries": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.6.tgz",
+      "integrity": "sha512-VciD13dswC4j1Xt5394WR4MzmAQmlgN72phd/riNp9vtD7tp4QQWJ0R4wvclXcafgcYK8veHRed2W6XeGBvcfg==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.20.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object.hasown": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/object.hasown/-/object.hasown-1.1.2.tgz",
+      "integrity": "sha512-B5UIT3J1W+WuWIU55h0mjlwaqxiE5vYENJXIXZ4VFe05pNYrkKuK0U/6aFcb0pKywYJh7IhfoqUfKVmrJJHZHw==",
+      "dev": true,
+      "dependencies": {
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.20.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object.values": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.6.tgz",
+      "integrity": "sha512-FVVTkD1vENCsAcwNs9k6jea2uHC/X0+JcjG8YA60FN5CMaJmG95wT9jek/xX9nornqGRrBkKtzuAu2wuHpKqvw==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.20.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/once": {
       "version": "1.4.0",
@@ -2636,6 +3353,17 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "dev": true,
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
     "node_modules/proxy-compare": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/proxy-compare/-/proxy-compare-2.4.0.tgz",
@@ -2693,6 +3421,12 @@
         "react": "^18.2.0"
       }
     },
+    "node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "dev": true
+    },
     "node_modules/react-refresh": {
       "version": "0.14.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.0.tgz",
@@ -2700,6 +3434,23 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/regexp.prototype.flags": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.4.3.tgz",
+      "integrity": "sha512-fjggEOO3slI6Wvgjwflkc4NFRCTZAu5CnNfBd5qOMYhWdn67nJBBu34/TkD++eeFmd8C9r9jfXJ27+nSiRkSUA==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3",
+        "functions-have-names": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/regexpp": {
@@ -2804,6 +3555,20 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "node_modules/safe-regex-test": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.0.0.tgz",
+      "integrity": "sha512-JBUUzyOgEwXQY1NuPtvcj/qcBDbDmEvWufhlnXZIm75DEHp+afM1r1ujJpJsV/gSM4t59tpDyPi1sd6ZaPFfsA==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "get-intrinsic": "^1.1.3",
+        "is-regex": "^1.1.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/scheduler": {
       "version": "0.23.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.0.tgz",
@@ -2842,6 +3607,20 @@
         "node": ">=8"
       }
     },
+    "node_modules/side-channel": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
+      "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.0",
+        "get-intrinsic": "^1.0.2",
+        "object-inspect": "^1.9.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -2858,6 +3637,53 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/string.prototype.matchall": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.8.tgz",
+      "integrity": "sha512-6zOCOcJ+RJAQshcTvXPHoxoQGONa3e/Lqx90wUA+wEzX78sg5Bo+1tQo4N0pohS0erG9qtCqJDjNCQBjeWVxyg==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.20.4",
+        "get-intrinsic": "^1.1.3",
+        "has-symbols": "^1.0.3",
+        "internal-slot": "^1.0.3",
+        "regexp.prototype.flags": "^1.4.3",
+        "side-channel": "^1.0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/string.prototype.trimend": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.6.tgz",
+      "integrity": "sha512-JySq+4mrPf9EsDBEDYMOb/lM7XQLulwg5R/m1r0PXEFqrV0qHvl58sdTilSXtKOflCsK2E8jxf+GKC0T07RWwQ==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.20.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/string.prototype.trimstart": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.6.tgz",
+      "integrity": "sha512-omqjMDaY92pbn5HOX7f9IccLA+U1tA9GvtU4JrodiXFfYB7jPzzHpRzpglLAjtUV6bB557zwClJezTqnAiYnQA==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.20.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/strip-ansi": {
@@ -2980,6 +3806,20 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/typed-array-length": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.4.tgz",
+      "integrity": "sha512-KjZypGq+I/H7HI5HlOoGHkWUUGq+Q0TPhQurLbyrVrvnKTBgzLhIJ7j6J/XTQOi0d1RjyZ0wdas8bKs2p0x3Ng==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "for-each": "^0.3.3",
+        "is-typed-array": "^1.1.9"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/typescript": {
       "version": "4.9.4",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.4.tgz",
@@ -2991,6 +3831,21 @@
       },
       "engines": {
         "node": ">=4.2.0"
+      }
+    },
+    "node_modules/unbox-primitive": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
+      "integrity": "sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "has-bigints": "^1.0.2",
+        "has-symbols": "^1.0.3",
+        "which-boxed-primitive": "^1.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/update-browserslist-db": {
@@ -3134,6 +3989,42 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/which-boxed-primitive": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz",
+      "integrity": "sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==",
+      "dev": true,
+      "dependencies": {
+        "is-bigint": "^1.0.1",
+        "is-boolean-object": "^1.1.0",
+        "is-number-object": "^1.0.4",
+        "is-string": "^1.0.5",
+        "is-symbol": "^1.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-typed-array": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.9.tgz",
+      "integrity": "sha512-w9c4xkx6mPidwp7180ckYWfMmvxpjlZuIudNtDf4N/tTAUB8VJbX25qZoAsrtGuYNnGw3pa0AXgbGKRB8/EceA==",
+      "dev": true,
+      "dependencies": {
+        "available-typed-arrays": "^1.0.5",
+        "call-bind": "^1.0.2",
+        "for-each": "^0.3.3",
+        "gopd": "^1.0.1",
+        "has-tostringtag": "^1.0.0",
+        "is-typed-array": "^1.1.10"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/word-wrap": {
@@ -3987,10 +4878,54 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true
     },
+    "array-includes": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.6.tgz",
+      "integrity": "sha512-sgTbLvL6cNnw24FnbaDyjmvddQ2ML8arZsgaJhoABMoplz/4QRhtrYS+alr1BUM1Bwp6dhx8vVCBSLG+StwOFw==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.20.4",
+        "get-intrinsic": "^1.1.3",
+        "is-string": "^1.0.7"
+      }
+    },
     "array-union": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
       "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+      "dev": true
+    },
+    "array.prototype.flatmap": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.3.1.tgz",
+      "integrity": "sha512-8UGn9O1FDVvMNB0UlLv4voxRMze7+FpHyF5mSMRjWHUMlpoDViniy05870VlxhfgTnLbpuwTzvD76MTtWxB/mQ==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.20.4",
+        "es-shim-unscopables": "^1.0.0"
+      }
+    },
+    "array.prototype.tosorted": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array.prototype.tosorted/-/array.prototype.tosorted-1.1.1.tgz",
+      "integrity": "sha512-pZYPXPRl2PqWcsUs6LOMn+1f1532nEoPTYowBtqLwAW+W8vSVhkIGnmOX1t/UQjD6YGI0vcD2B1U7ZFGQH9jnQ==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.20.4",
+        "es-shim-unscopables": "^1.0.0",
+        "get-intrinsic": "^1.1.3"
+      }
+    },
+    "available-typed-arrays": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
+      "integrity": "sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==",
       "dev": true
     },
     "balanced-match": {
@@ -4028,6 +4963,16 @@
         "electron-to-chromium": "^1.4.251",
         "node-releases": "^2.0.6",
         "update-browserslist-db": "^1.0.9"
+      }
+    },
+    "call-bind": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+      "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+      "dev": true,
+      "requires": {
+        "function-bind": "^1.1.1",
+        "get-intrinsic": "^1.0.2"
       }
     },
     "callsites": {
@@ -4112,6 +5057,16 @@
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true
     },
+    "define-properties": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.0.tgz",
+      "integrity": "sha512-xvqAVKGfT1+UAvPwKTVw/njhdQ8ZhXK4lI0bCIuCMrp2up9nPnaDftrLtmpTazqd1o+UY4zgzU+avtMbDP+ldA==",
+      "dev": true,
+      "requires": {
+        "has-property-descriptors": "^1.0.0",
+        "object-keys": "^1.1.1"
+      }
+    },
     "dir-glob": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
@@ -4135,6 +5090,78 @@
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.284.tgz",
       "integrity": "sha512-M8WEXFuKXMYMVr45fo8mq0wUrrJHheiKZf6BArTKk9ZBYCKJEOU5H8cdWgDT+qCVZf7Na4lVUaZsA+h6uA9+PA==",
       "dev": true
+    },
+    "es-abstract": {
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.21.1.tgz",
+      "integrity": "sha512-QudMsPOz86xYz/1dG1OuGBKOELjCh99IIWHLzy5znUB6j8xG2yMA7bfTV86VSqKF+Y/H08vQPR+9jyXpuC6hfg==",
+      "dev": true,
+      "requires": {
+        "available-typed-arrays": "^1.0.5",
+        "call-bind": "^1.0.2",
+        "es-set-tostringtag": "^2.0.1",
+        "es-to-primitive": "^1.2.1",
+        "function-bind": "^1.1.1",
+        "function.prototype.name": "^1.1.5",
+        "get-intrinsic": "^1.1.3",
+        "get-symbol-description": "^1.0.0",
+        "globalthis": "^1.0.3",
+        "gopd": "^1.0.1",
+        "has": "^1.0.3",
+        "has-property-descriptors": "^1.0.0",
+        "has-proto": "^1.0.1",
+        "has-symbols": "^1.0.3",
+        "internal-slot": "^1.0.4",
+        "is-array-buffer": "^3.0.1",
+        "is-callable": "^1.2.7",
+        "is-negative-zero": "^2.0.2",
+        "is-regex": "^1.1.4",
+        "is-shared-array-buffer": "^1.0.2",
+        "is-string": "^1.0.7",
+        "is-typed-array": "^1.1.10",
+        "is-weakref": "^1.0.2",
+        "object-inspect": "^1.12.2",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.4",
+        "regexp.prototype.flags": "^1.4.3",
+        "safe-regex-test": "^1.0.0",
+        "string.prototype.trimend": "^1.0.6",
+        "string.prototype.trimstart": "^1.0.6",
+        "typed-array-length": "^1.0.4",
+        "unbox-primitive": "^1.0.2",
+        "which-typed-array": "^1.1.9"
+      }
+    },
+    "es-set-tostringtag": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.0.1.tgz",
+      "integrity": "sha512-g3OMbtlwY3QewlqAiMLI47KywjWZoEytKr8pf6iTC8uJq5bIAH52Z9pnQ8pVL6whrCto53JZDuUIsifGeLorTg==",
+      "dev": true,
+      "requires": {
+        "get-intrinsic": "^1.1.3",
+        "has": "^1.0.3",
+        "has-tostringtag": "^1.0.0"
+      }
+    },
+    "es-shim-unscopables": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/es-shim-unscopables/-/es-shim-unscopables-1.0.0.tgz",
+      "integrity": "sha512-Jm6GPcCdC30eMLbZ2x8z2WuRwAws3zTBBKuusffYVUrNj/GVSUAZ+xKMaUpfNDR5IbyNA5LJbaecoUVbmUcB1w==",
+      "dev": true,
+      "requires": {
+        "has": "^1.0.3"
+      }
+    },
+    "es-to-primitive": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
+      "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
+      "dev": true,
+      "requires": {
+        "is-callable": "^1.1.4",
+        "is-date-object": "^1.0.1",
+        "is-symbol": "^1.0.2"
+      }
     },
     "esbuild": {
       "version": "0.16.16",
@@ -4321,6 +5348,57 @@
       "dev": true,
       "requires": {
         "prettier-linter-helpers": "^1.0.0"
+      }
+    },
+    "eslint-plugin-react": {
+      "version": "7.32.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.32.2.tgz",
+      "integrity": "sha512-t2fBMa+XzonrrNkyVirzKlvn5RXzzPwRHtMvLAtVZrt8oxgnTQaYbU6SXTOO1mwQgp1y5+toMSKInnzGr0Knqg==",
+      "dev": true,
+      "requires": {
+        "array-includes": "^3.1.6",
+        "array.prototype.flatmap": "^1.3.1",
+        "array.prototype.tosorted": "^1.1.1",
+        "doctrine": "^2.1.0",
+        "estraverse": "^5.3.0",
+        "jsx-ast-utils": "^2.4.1 || ^3.0.0",
+        "minimatch": "^3.1.2",
+        "object.entries": "^1.1.6",
+        "object.fromentries": "^2.0.6",
+        "object.hasown": "^1.1.2",
+        "object.values": "^1.1.6",
+        "prop-types": "^15.8.1",
+        "resolve": "^2.0.0-next.4",
+        "semver": "^6.3.0",
+        "string.prototype.matchall": "^4.0.8"
+      },
+      "dependencies": {
+        "doctrine": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+          "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+          "dev": true,
+          "requires": {
+            "esutils": "^2.0.2"
+          }
+        },
+        "estraverse": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+          "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+          "dev": true
+        },
+        "resolve": {
+          "version": "2.0.0-next.4",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.4.tgz",
+          "integrity": "sha512-iMDbmAWtfU+MHpxt/I5iWI7cY6YVEZUQ3MBgPQ++XD1PELuJHIl82xBmObyP2KyQmkNB2dsqF7seoQQiAn5yDQ==",
+          "dev": true,
+          "requires": {
+            "is-core-module": "^2.9.0",
+            "path-parse": "^1.0.7",
+            "supports-preserve-symlinks-flag": "^1.0.0"
+          }
+        }
       }
     },
     "eslint-scope": {
@@ -4514,6 +5592,15 @@
       "integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==",
       "dev": true
     },
+    "for-each": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
+      "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
+      "dev": true,
+      "requires": {
+        "is-callable": "^1.1.3"
+      }
+    },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -4533,11 +5620,50 @@
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
       "dev": true
     },
+    "function.prototype.name": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.5.tgz",
+      "integrity": "sha512-uN7m/BzVKQnCUF/iW8jYea67v++2u7m5UgENbHRtdDVclOUP+FMPlCNdmk0h/ysGyo2tavMJEDqJAkJdRa1vMA==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.19.0",
+        "functions-have-names": "^1.2.2"
+      }
+    },
+    "functions-have-names": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
+      "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
+      "dev": true
+    },
     "gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
       "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
       "dev": true
+    },
+    "get-intrinsic": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.0.tgz",
+      "integrity": "sha512-L049y6nFOuom5wGyRc3/gdTLO94dySVKRACj1RmJZBQXlbTMhtNIgkWkUHq+jYmZvKf14EW1EoJnnjbmoHij0Q==",
+      "dev": true,
+      "requires": {
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "has-symbols": "^1.0.3"
+      }
+    },
+    "get-symbol-description": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.0.0.tgz",
+      "integrity": "sha512-2EmdH1YvIQiZpltCNgkuiUnyukzxM/R6NDJX31Ke3BG1Nq5b0S2PhX59UKi9vZpPDQVdqn+1IcaAwnzTT5vCjw==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "get-intrinsic": "^1.1.1"
+      }
     },
     "glob": {
       "version": "7.2.3",
@@ -4568,6 +5694,15 @@
       "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
       "dev": true
     },
+    "globalthis": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.3.tgz",
+      "integrity": "sha512-sFdI5LyBiNTHjRd7cGPWapiHWMOXKyuBNX/cWJ3NfzrZQVa8GI/8cofCl74AOVqq9W5kNmguTIzJ/1s2gyI9wA==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3"
+      }
+    },
     "globby": {
       "version": "11.1.0",
       "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
@@ -4580,6 +5715,15 @@
         "ignore": "^5.2.0",
         "merge2": "^1.4.1",
         "slash": "^3.0.0"
+      }
+    },
+    "gopd": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
+      "integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
+      "dev": true,
+      "requires": {
+        "get-intrinsic": "^1.1.3"
       }
     },
     "grapheme-splitter": {
@@ -4597,11 +5741,47 @@
         "function-bind": "^1.1.1"
       }
     },
+    "has-bigints": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
+      "integrity": "sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==",
+      "dev": true
+    },
     "has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
       "dev": true
+    },
+    "has-property-descriptors": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.0.tgz",
+      "integrity": "sha512-62DVLZGoiEBDHQyqG4w9xCuZ7eJEwNmJRWw2VY84Oedb7WFcA27fiEVe8oUQx9hAUJ4ekurquucTGwsyO1XGdQ==",
+      "dev": true,
+      "requires": {
+        "get-intrinsic": "^1.1.1"
+      }
+    },
+    "has-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.1.tgz",
+      "integrity": "sha512-7qE+iP+O+bgF9clE5+UoBFzE65mlBiVj3tKCrlNQ0Ogwm0BjpT/gK4SlLYDMybDh5I3TCTKnPPa0oMG7JDYrhg==",
+      "dev": true
+    },
+    "has-symbols": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
+      "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
+      "dev": true
+    },
+    "has-tostringtag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.0.tgz",
+      "integrity": "sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==",
+      "dev": true,
+      "requires": {
+        "has-symbols": "^1.0.2"
+      }
     },
     "ignore": {
       "version": "5.2.4",
@@ -4641,6 +5821,53 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true
     },
+    "internal-slot": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.5.tgz",
+      "integrity": "sha512-Y+R5hJrzs52QCG2laLn4udYVnxsfny9CpOhNhUvk/SSSVyF6T27FzRbF0sroPidSu3X8oEAkOn2K804mjpt6UQ==",
+      "dev": true,
+      "requires": {
+        "get-intrinsic": "^1.2.0",
+        "has": "^1.0.3",
+        "side-channel": "^1.0.4"
+      }
+    },
+    "is-array-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.1.tgz",
+      "integrity": "sha512-ASfLknmY8Xa2XtB4wmbz13Wu202baeA18cJBCeCy0wXUHZF0IPyVEXqKEcd+t2fNSLLL1vC6k7lxZEojNbISXQ==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "get-intrinsic": "^1.1.3",
+        "is-typed-array": "^1.1.10"
+      }
+    },
+    "is-bigint": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.4.tgz",
+      "integrity": "sha512-zB9CruMamjym81i2JZ3UMn54PKGsQzsJeo6xvN3HJJ4CAsQNB6iRutp2To77OfCNuoxspsIhzaPoO1zyCEhFOg==",
+      "dev": true,
+      "requires": {
+        "has-bigints": "^1.0.1"
+      }
+    },
+    "is-boolean-object": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.2.tgz",
+      "integrity": "sha512-gDYaKHJmnj4aWxyj6YHyXVpdQawtVLHU5cb+eztPGczf6cjuTdwve5ZIEfgXqH4e57An1D1AKf8CZ3kYrQRqYA==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "has-tostringtag": "^1.0.0"
+      }
+    },
+    "is-callable": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+      "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
+      "dev": true
+    },
     "is-core-module": {
       "version": "2.11.0",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.11.0.tgz",
@@ -4648,6 +5875,15 @@
       "dev": true,
       "requires": {
         "has": "^1.0.3"
+      }
+    },
+    "is-date-object": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.5.tgz",
+      "integrity": "sha512-9YQaSxsAiSwcvS33MBk3wTCVnWK+HhF8VZR2jRxehM16QcVOdHqPn4VPHmRK4lSr38n9JriurInLcP90xsYNfQ==",
+      "dev": true,
+      "requires": {
+        "has-tostringtag": "^1.0.0"
       }
     },
     "is-extglob": {
@@ -4665,17 +5901,91 @@
         "is-extglob": "^2.1.1"
       }
     },
+    "is-negative-zero": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.2.tgz",
+      "integrity": "sha512-dqJvarLawXsFbNDeJW7zAz8ItJ9cd28YufuuFzh0G8pNHjJMnY08Dv7sYX2uF5UpQOwieAeOExEYAWWfu7ZZUA==",
+      "dev": true
+    },
     "is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
       "dev": true
     },
+    "is-number-object": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.7.tgz",
+      "integrity": "sha512-k1U0IRzLMo7ZlYIfzRu23Oh6MiIFasgpb9X76eqfFZAqwH44UI4KTBvBYIZ1dSL9ZzChTB9ShHfLkR4pdW5krQ==",
+      "dev": true,
+      "requires": {
+        "has-tostringtag": "^1.0.0"
+      }
+    },
     "is-path-inside": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
       "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
       "dev": true
+    },
+    "is-regex": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
+      "integrity": "sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "has-tostringtag": "^1.0.0"
+      }
+    },
+    "is-shared-array-buffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.2.tgz",
+      "integrity": "sha512-sqN2UDu1/0y6uvXyStCOzyhAjCSlHceFoMKJW8W9EU9cvic/QdsZ0kEU93HEy3IUEFZIiH/3w+AH/UQbPHNdhA==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2"
+      }
+    },
+    "is-string": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.7.tgz",
+      "integrity": "sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==",
+      "dev": true,
+      "requires": {
+        "has-tostringtag": "^1.0.0"
+      }
+    },
+    "is-symbol": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.4.tgz",
+      "integrity": "sha512-C/CPBqKWnvdcxqIARxyOh4v1UUEOCHpgDa0WYgpKDFMszcrPcffg5uhwSgPCLD2WWxmq6isisz87tzT01tuGhg==",
+      "dev": true,
+      "requires": {
+        "has-symbols": "^1.0.2"
+      }
+    },
+    "is-typed-array": {
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.10.tgz",
+      "integrity": "sha512-PJqgEHiWZvMpaFZ3uTc8kHPM4+4ADTlDniuQL7cU/UDA0Ql7F70yGfHph3cLNe+c9toaigv+DFzTJKhc2CtO6A==",
+      "dev": true,
+      "requires": {
+        "available-typed-arrays": "^1.0.5",
+        "call-bind": "^1.0.2",
+        "for-each": "^0.3.3",
+        "gopd": "^1.0.1",
+        "has-tostringtag": "^1.0.0"
+      }
+    },
+    "is-weakref": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.2.tgz",
+      "integrity": "sha512-qctsuLZmIQ0+vSSMfoVvyFe2+GSEvnmZ2ezTup1SBse9+twCCeial6EEi3Nc2KFcf6+qz2FBPnjXsk8xhKSaPQ==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2"
+      }
     },
     "isexe": {
       "version": "2.0.0",
@@ -4726,6 +6036,16 @@
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
       "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
       "dev": true
+    },
+    "jsx-ast-utils": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.3.tgz",
+      "integrity": "sha512-fYQHZTZ8jSfmWZ0iyzfwiU4WDX4HpHbMCZ3gPlWYiCl3BoeOTsqKBqnTVfH2rYT7eP5c3sVbeSPHnnJOaTrWiw==",
+      "dev": true,
+      "requires": {
+        "array-includes": "^3.1.5",
+        "object.assign": "^4.1.3"
+      }
     },
     "levn": {
       "version": "0.4.1",
@@ -4832,6 +6152,79 @@
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.8.tgz",
       "integrity": "sha512-dFSmB8fFHEH/s81Xi+Y/15DQY6VHW81nXRj86EMSL3lmuTmK1e+aT4wrFCkTbm+gSwkw4KpX+rT/pMM2c1mF+A==",
       "dev": true
+    },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "dev": true
+    },
+    "object-inspect": {
+      "version": "1.12.3",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.3.tgz",
+      "integrity": "sha512-geUvdk7c+eizMNUDkRpW1wJwgfOiOeHbxBR/hLXK1aT6zmVSO0jsQcs7fj6MGw89jC/cjGfLcNOrtMYtGqm81g==",
+      "dev": true
+    },
+    "object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true
+    },
+    "object.assign": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.4.tgz",
+      "integrity": "sha512-1mxKf0e58bvyjSCtKYY4sRe9itRk3PJpquJOjeIkz885CczcI4IvJJDLPS72oowuSh+pBxUFROpX+TU++hxhZQ==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.4",
+        "has-symbols": "^1.0.3",
+        "object-keys": "^1.1.1"
+      }
+    },
+    "object.entries": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.6.tgz",
+      "integrity": "sha512-leTPzo4Zvg3pmbQ3rDK69Rl8GQvIqMWubrkxONG9/ojtFE2rD9fjMKfSI5BxW3osRH1m6VdzmqK8oAY9aT4x5w==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.20.4"
+      }
+    },
+    "object.fromentries": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.6.tgz",
+      "integrity": "sha512-VciD13dswC4j1Xt5394WR4MzmAQmlgN72phd/riNp9vtD7tp4QQWJ0R4wvclXcafgcYK8veHRed2W6XeGBvcfg==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.20.4"
+      }
+    },
+    "object.hasown": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/object.hasown/-/object.hasown-1.1.2.tgz",
+      "integrity": "sha512-B5UIT3J1W+WuWIU55h0mjlwaqxiE5vYENJXIXZ4VFe05pNYrkKuK0U/6aFcb0pKywYJh7IhfoqUfKVmrJJHZHw==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.20.4"
+      }
+    },
+    "object.values": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.6.tgz",
+      "integrity": "sha512-FVVTkD1vENCsAcwNs9k6jea2uHC/X0+JcjG8YA60FN5CMaJmG95wT9jek/xX9nornqGRrBkKtzuAu2wuHpKqvw==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.20.4"
+      }
     },
     "once": {
       "version": "1.4.0",
@@ -4957,6 +6350,17 @@
         "fast-diff": "^1.1.2"
       }
     },
+    "prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "dev": true,
+      "requires": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
     "proxy-compare": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/proxy-compare/-/proxy-compare-2.4.0.tgz",
@@ -4991,11 +6395,28 @@
         "scheduler": "^0.23.0"
       }
     },
+    "react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "dev": true
+    },
     "react-refresh": {
       "version": "0.14.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.0.tgz",
       "integrity": "sha512-wViHqhAd8OHeLS/IRMJjTSDHF3U9eWi62F/MledQGPdJGDhodXJ9PBLNGr6WWL7qlH12Mt3TyTpbS+hGXMjCzQ==",
       "dev": true
+    },
+    "regexp.prototype.flags": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.4.3.tgz",
+      "integrity": "sha512-fjggEOO3slI6Wvgjwflkc4NFRCTZAu5CnNfBd5qOMYhWdn67nJBBu34/TkD++eeFmd8C9r9jfXJ27+nSiRkSUA==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3",
+        "functions-have-names": "^1.2.2"
+      }
     },
     "regexpp": {
       "version": "3.2.0",
@@ -5053,6 +6474,17 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "safe-regex-test": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.0.0.tgz",
+      "integrity": "sha512-JBUUzyOgEwXQY1NuPtvcj/qcBDbDmEvWufhlnXZIm75DEHp+afM1r1ujJpJsV/gSM4t59tpDyPi1sd6ZaPFfsA==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "get-intrinsic": "^1.1.3",
+        "is-regex": "^1.1.4"
+      }
+    },
     "scheduler": {
       "version": "0.23.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.0.tgz",
@@ -5082,6 +6514,17 @@
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
       "dev": true
     },
+    "side-channel": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
+      "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.0",
+        "get-intrinsic": "^1.0.2",
+        "object-inspect": "^1.9.0"
+      }
+    },
     "slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -5093,6 +6536,44 @@
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
       "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
       "dev": true
+    },
+    "string.prototype.matchall": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.8.tgz",
+      "integrity": "sha512-6zOCOcJ+RJAQshcTvXPHoxoQGONa3e/Lqx90wUA+wEzX78sg5Bo+1tQo4N0pohS0erG9qtCqJDjNCQBjeWVxyg==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.20.4",
+        "get-intrinsic": "^1.1.3",
+        "has-symbols": "^1.0.3",
+        "internal-slot": "^1.0.3",
+        "regexp.prototype.flags": "^1.4.3",
+        "side-channel": "^1.0.4"
+      }
+    },
+    "string.prototype.trimend": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.6.tgz",
+      "integrity": "sha512-JySq+4mrPf9EsDBEDYMOb/lM7XQLulwg5R/m1r0PXEFqrV0qHvl58sdTilSXtKOflCsK2E8jxf+GKC0T07RWwQ==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.20.4"
+      }
+    },
+    "string.prototype.trimstart": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.6.tgz",
+      "integrity": "sha512-omqjMDaY92pbn5HOX7f9IccLA+U1tA9GvtU4JrodiXFfYB7jPzzHpRzpglLAjtUV6bB557zwClJezTqnAiYnQA==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.20.4"
+      }
     },
     "strip-ansi": {
       "version": "6.0.1",
@@ -5175,11 +6656,34 @@
       "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
       "dev": true
     },
+    "typed-array-length": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.4.tgz",
+      "integrity": "sha512-KjZypGq+I/H7HI5HlOoGHkWUUGq+Q0TPhQurLbyrVrvnKTBgzLhIJ7j6J/XTQOi0d1RjyZ0wdas8bKs2p0x3Ng==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "for-each": "^0.3.3",
+        "is-typed-array": "^1.1.9"
+      }
+    },
     "typescript": {
       "version": "4.9.4",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.4.tgz",
       "integrity": "sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==",
       "dev": true
+    },
+    "unbox-primitive": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
+      "integrity": "sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "has-bigints": "^1.0.2",
+        "has-symbols": "^1.0.3",
+        "which-boxed-primitive": "^1.0.2"
+      }
     },
     "update-browserslist-db": {
       "version": "1.0.10",
@@ -5244,6 +6748,33 @@
       "dev": true,
       "requires": {
         "isexe": "^2.0.0"
+      }
+    },
+    "which-boxed-primitive": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz",
+      "integrity": "sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==",
+      "dev": true,
+      "requires": {
+        "is-bigint": "^1.0.1",
+        "is-boolean-object": "^1.1.0",
+        "is-number-object": "^1.0.4",
+        "is-string": "^1.0.5",
+        "is-symbol": "^1.0.3"
+      }
+    },
+    "which-typed-array": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.9.tgz",
+      "integrity": "sha512-w9c4xkx6mPidwp7180ckYWfMmvxpjlZuIudNtDf4N/tTAUB8VJbX25qZoAsrtGuYNnGw3pa0AXgbGKRB8/EceA==",
+      "dev": true,
+      "requires": {
+        "available-typed-arrays": "^1.0.5",
+        "call-bind": "^1.0.2",
+        "for-each": "^0.3.3",
+        "gopd": "^1.0.1",
+        "has-tostringtag": "^1.0.0",
+        "is-typed-array": "^1.1.10"
       }
     },
     "word-wrap": {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "eslint": "^8.32.0",
     "eslint-config-prettier": "^8.6.0",
     "eslint-plugin-prettier": "^4.2.1",
+    "eslint-plugin-react": "^7.32.2",
     "prettier": "^2.8.3",
     "typescript": "^4.9.3",
     "vite": "^4.0.0",

--- a/src/App.css
+++ b/src/App.css
@@ -54,6 +54,11 @@ span.aas-label {
     margin-right: 1em;
 }
 
+span.aas-label-with-errors {
+    margin-right: 1em;
+    color: red;
+}
+
 div.aas-field {
     display: flex;
     vertical-align: top;
@@ -62,4 +67,19 @@ div.aas-field {
 span.aas-error-path {
     color: red;
     margin-right: 5em;
+}
+span.aas-error-message {
+    color: red;
+}
+
+summary.aas-list-item-with-errors {
+    color: red;
+}
+
+h1.aas-environment-title-with-errors {
+    color: red;
+}
+
+div.aas-errors h1 {
+    color: red;
 }

--- a/src/components/Environment.tsx
+++ b/src/components/Environment.tsx
@@ -2,7 +2,8 @@ import * as aas from "@aas-core-works/aas-core3.0rc02-typescript";
 import * as React from 'react';
 
 import * as instances from "./instances";
-import * as verification from "../verification"
+import * as model from "../model";
+import {HelpLink} from "./fields/HelpLink";
 
 export function Environment(
   props: {
@@ -10,9 +11,30 @@ export function Environment(
     instance: aas.types.Environment
   }
 ) {
+  const errorSet = model.getErrorSet(props.instance);
+  const descendantsWithErrors = model.getDescendantsWithErrors(props.instance);
+  const [hasErrors, setHasErrors] = React.useState(false);
+
+  React.useEffect(
+    () => {
+      setHasErrors(
+        errorSet.size > 0 || descendantsWithErrors.size > 0
+      )
+    },
+    [
+      errorSet.versioning.version,
+      descendantsWithErrors.versioning.version
+    ]
+  )
+
   return (
     <div className="aas-root">
-      <h1>Environment</h1>
+      <h1 className={
+        !hasErrors
+          ? "aas-environment-title"
+          : "aas-environment-title-with-errors"
+      }
+      >Environment</h1>
       <ul className="aas-tree">
         <instances.EnvironmentFields
           snapInstance={props.snapInstance}

--- a/src/components/fields/BooleanFieldOptional.tsx
+++ b/src/components/fields/BooleanFieldOptional.tsx
@@ -1,15 +1,17 @@
 import * as React from "react";
 
 import * as incrementalid from "../../incrementalid";
+import * as enhancing from "../../enhancing.generated";
 
-import {HelpLink} from "./HelpLink";
+import {NonCompositeField} from "./NonCompositeField";
 
 export function BooleanFieldOptional(
   props: {
     label: string,
     helpUrl: string | null,
     value: boolean | null,
-    onChange: (value: boolean | null) => void
+    onChange: (value: boolean | null) => void,
+    errors: Array<enhancing.TimestampedError> | null
   }
 ) {
   const name = React.useState(incrementalid.next())[0];
@@ -18,30 +20,24 @@ export function BooleanFieldOptional(
   const nothingId = React.useState(incrementalid.next())[0];
 
   return (
-    <li>
-      <div className="aas-field">
-        <span className="aas-label">
-          {props.label}<HelpLink helpUrl={props.helpUrl}/>:
-        </span>
+    <NonCompositeField label={props.label} helpUrl={props.helpUrl} errors={props.errors}>
+      <input type="radio" name={name} id={nothingId} value="null"
+             onClick={() => props.onChange(null)}
+             checked={props.value === null}
+      />
+      <label htmlFor={nothingId}>Not specified</label>
 
-        <input type="radio" name={name} id={nothingId} value="null"
-               onClick={() => props.onChange(null)}
-               checked={props.value === null}
-        />
-        <label htmlFor={nothingId}>Not specified</label>
+      <input type="radio" name={name} id={noId}
+             onClick={() => props.onChange(false)}
+             checked={props.value === false}
+      />
+      <label htmlFor={noId}>No</label>
 
-        <input type="radio" name={name} id={noId}
-               onClick={() => props.onChange(false)}
-               checked={props.value === false}
-        />
-        <label htmlFor={noId}>No</label>
-
-        <input type="radio" name={name} id={yesId} value="1"
-               onClick={() => props.onChange(true)}
-               checked={props.value === true}
-        />
-        <label htmlFor={yesId}>Yes</label>
-      </div>
-    </li>
+      <input type="radio" name={name} id={yesId} value="1"
+             onClick={() => props.onChange(true)}
+             checked={props.value === true}
+      />
+      <label htmlFor={yesId}>Yes</label>
+    </NonCompositeField>
   )
 }

--- a/src/components/fields/BooleanFieldRequired.tsx
+++ b/src/components/fields/BooleanFieldRequired.tsx
@@ -1,35 +1,28 @@
 import * as React from "react";
 
-import * as incrementalid from "../../incrementalid";
+import * as enhancing from "../../enhancing.generated";
 
-import {HelpLink} from "./HelpLink";
+import {NonCompositeField} from "./NonCompositeField";
 
 export function BooleanFieldRequired(
   props: {
     label: string,
     helpUrl: string | null,
     value: boolean,
-    onChange: (value: boolean) => void
+    onChange: (value: boolean) => void,
+    errors: Array<enhancing.TimestampedError> | null
   }
 ) {
-  const inputId = React.useState(incrementalid.next())[0];
-
   return (
-    <li>
-      <div className="aas-field">
-        <span className="aas-label">
-          {props.label}<HelpLink helpUrl={props.helpUrl}/>:
-        </span>
-
-        <input type="checkbox" id={inputId}
-               checked={props.value}
-               onChange={
-                 (event) => {
-                   props.onChange(event.target.checked)
-                 }
+    <NonCompositeField label={props.label} helpUrl={props.helpUrl} errors={props.errors}>
+      <input type="checkbox"
+             checked={props.value}
+             onChange={
+               (event) => {
+                 props.onChange(event.target.checked)
                }
-        />
-      </div>
-    </li>
+             }
+      />
+    </NonCompositeField>
   )
 }

--- a/src/components/fields/ByteArrayFieldOptional.tsx
+++ b/src/components/fields/ByteArrayFieldOptional.tsx
@@ -1,8 +1,9 @@
 import * as React from "react"
 
 import * as widgets from '../widgets'
+import * as enhancing from "../../enhancing.generated";
 
-import {HelpLink} from './HelpLink'
+import {NonCompositeField} from "./NonCompositeField";
 
 export function ByteArrayFieldOptional(
   props: {
@@ -10,29 +11,24 @@ export function ByteArrayFieldOptional(
     helpUrl: string | null,
     value: Uint8Array | null,
     onChange: (value: Uint8Array | null) => void,
-    contentType: string | null
+    contentType: string | null,
+    errors: Array<enhancing.TimestampedError> | null
   }
 ) {
   return (
-    <li>
-      <div className="aas-field">
-        <span className="aas-label">
-          {props.label}<HelpLink helpUrl={props.helpUrl}/>:
-        </span>
-
-        <widgets.BytesContainer
-          content={props.value}
-          setContent={(content: Uint8Array) => {
-            if (content.length === 0) {
-              props.onChange(null);
-            } else {
-              props.onChange(content);
-            }
-          }}
-          clear={() => props.onChange(null)}
-          contentType={props.contentType}
-        />
-      </div>
-    </li>
+    <NonCompositeField label={props.label} helpUrl={props.helpUrl} errors={props.errors}>
+      <widgets.BytesContainer
+        content={props.value}
+        setContent={(content: Uint8Array) => {
+          if (content.length === 0) {
+            props.onChange(null);
+          } else {
+            props.onChange(content);
+          }
+        }}
+        clear={() => props.onChange(null)}
+        contentType={props.contentType}
+      />
+    </NonCompositeField>
   )
 }

--- a/src/components/fields/ByteArrayFieldRequired.tsx
+++ b/src/components/fields/ByteArrayFieldRequired.tsx
@@ -1,8 +1,9 @@
 import * as React from "react"
 
 import * as widgets from '../widgets'
+import * as enhancing from "../../enhancing.generated";
 
-import {HelpLink} from "./HelpLink"
+import {NonCompositeField} from "./NonCompositeField";
 
 export function ByteArrayFieldRequired(
   props: {
@@ -10,23 +11,18 @@ export function ByteArrayFieldRequired(
     helpUrl: string | null,
     value: Uint8Array,
     onChange: (value: Uint8Array) => void,
-    contentType: string | null
+    contentType: string | null,
+    errors: Array<enhancing.TimestampedError> | null
   }
 ) {
   return (
-    <li>
-      <div className="aas-field">
-        <span className="aas-label">
-          {props.label}<HelpLink helpUrl={props.helpUrl}/>:
-        </span>
-
-        <widgets.BytesContainer
-          content={props.value}
-          setContent={props.onChange}
-          clear={() => props.onChange(new Uint8Array())}
-          contentType={props.contentType}
-        />
-      </div>
-    </li>
+    <NonCompositeField label={props.label} helpUrl={props.helpUrl} errors={props.errors}>
+      <widgets.BytesContainer
+        content={props.value}
+        setContent={props.onChange}
+        clear={() => props.onChange(new Uint8Array())}
+        contentType={props.contentType}
+      />
+    </NonCompositeField>
   )
 }

--- a/src/components/fields/EmbeddedInstanceRequired.tsx
+++ b/src/components/fields/EmbeddedInstanceRequired.tsx
@@ -2,6 +2,7 @@ import * as aas from "@aas-core-works/aas-core3.0rc02-typescript";
 import * as React from 'react';
 
 import * as fielding from "../instances/fielding.generated";
+import * as model from "../../model";
 import * as newinstancing from "../../newinstancing.generated";
 
 import {HelpLink} from "./HelpLink";
@@ -18,6 +19,24 @@ export function EmbeddedInstanceRequired<ClassT extends aas.types.Class>(
     setInstance: (instance: ClassT) => void
   }
 ) {
+  const errorSet = model.getErrorSet(props.instance);
+
+  const descendantsWithErrors = model.getDescendantsWithErrors(props.instance);
+
+  const [hasErrors, setHasErrors] = React.useState(false);
+
+  React.useEffect(
+    () => {
+      setHasErrors(
+        errorSet.size > 0 || descendantsWithErrors.size > 0
+      )
+    },
+    [
+      errorSet.versioning.version,
+      descendantsWithErrors.versioning.version
+    ]
+  )
+
   const control = (
     props.newInstanceDefinitions.map(
       (definition) => {
@@ -44,13 +63,13 @@ export function EmbeddedInstanceRequired<ClassT extends aas.types.Class>(
 
   return (
     <li>
-      <span className="aas-label"
+      <span className={!hasErrors ? "aas-label" : "aas-label-with-errors"}
       >{props.label}<HelpLink helpUrl={props.helpUrl}/>:</span>
 
         <ul className="aas-embedded-instance">
           {
             fielding.componentFor(
-              props.instance!,
+              props.instance,
               props.snapInstance
             )
           }

--- a/src/components/fields/EnumerationFieldOptional.tsx
+++ b/src/components/fields/EnumerationFieldOptional.tsx
@@ -1,8 +1,8 @@
 import * as React from "react";
 
-import * as incrementalid from "../../incrementalid";
+import * as enhancing from "../../enhancing.generated";
 
-import {HelpLink} from "./HelpLink";
+import {NonCompositeField} from "./NonCompositeField";
 
 export function EnumerationFieldOptional<EnumT extends number>(
   props: {
@@ -11,11 +11,10 @@ export function EnumerationFieldOptional<EnumT extends number>(
     getLiterals: () => IterableIterator<EnumT>,
     literalToString: (literal: EnumT) => string,
     selected: EnumT | null,
-    onChange: (value: EnumT | null) => void
+    onChange: (value: EnumT | null) => void,
+    errors: Array<enhancing.TimestampedError> | null
   }
 ) {
-  const inputId = React.useState(incrementalid.next())[0];
-
   const valuesAndDescriptions = React.useState<Array<[string, string]>>(
     (() => {
       const realizedValuesAndDescriptions = new Array<[string, string]>();
@@ -32,46 +31,39 @@ export function EnumerationFieldOptional<EnumT extends number>(
   )[0];
 
   return (
-    <li>
-      <div className="aas-field">
-        <span className="aas-label">
-          {props.label}<HelpLink helpUrl={props.helpUrl}/>:
-        </span>
-
-        <select
-          id={inputId}
-          defaultValue={
-            props.selected === null ? "null" : props.selected.toString()
-          }
-          onChange={
-            (event) => {
-              if (event.target.value === "") {
-                props.onChange(null);
-              } else {
-                props.onChange(parseInt(event.target.value) as EnumT);
-              }
+    <NonCompositeField label={props.label} helpUrl={props.helpUrl} errors={props.errors}>
+      <select
+        defaultValue={
+          props.selected === null ? "null" : props.selected.toString()
+        }
+        onChange={
+          (event) => {
+            if (event.target.value === "") {
+              props.onChange(null);
+            } else {
+              props.onChange(parseInt(event.target.value) as EnumT);
             }
           }
+        }
+      >
+        <option
+          key="null"
+          value="null"
+          className="aas-unspecified-option"
         >
-          <option
-            key="null"
-            value="null"
-            className="aas-unspecified-option"
-          >
-            Not specified
-          </option>
+          Not specified
+        </option>
 
-          {
-            valuesAndDescriptions.map((valueAndDescription => {
-              const [value, description] = valueAndDescription;
+        {
+          valuesAndDescriptions.map((valueAndDescription => {
+            const [value, description] = valueAndDescription;
 
-              return (
-                <option key={value} value={value}>{description}</option>
-              )
-            }))
-          }
-        </select>
-      </div>
-    </li>
+            return (
+              <option key={value} value={value}>{description}</option>
+            )
+          }))
+        }
+      </select>
+    </NonCompositeField>
   )
 }

--- a/src/components/fields/EnumerationFieldRequired.tsx
+++ b/src/components/fields/EnumerationFieldRequired.tsx
@@ -1,8 +1,8 @@
 import * as React from "react";
 
-import * as incrementalid from "../../incrementalid";
+import * as enhancing from "../../enhancing.generated";
 
-import {HelpLink} from "./HelpLink";
+import {NonCompositeField} from "./NonCompositeField";
 
 export function EnumerationFieldRequired<EnumT extends number>(
   props: {
@@ -11,12 +11,10 @@ export function EnumerationFieldRequired<EnumT extends number>(
     getLiterals: () => IterableIterator<EnumT>,
     literalToString: (literal: EnumT) => string,
     selected: EnumT,
-    onChange: (value: EnumT) => void
+    onChange: (value: EnumT) => void,
+    errors: Array<enhancing.TimestampedError> | null
   }
 ) {
-  // noinspection DuplicatedCode
-  const inputId = React.useState(incrementalid.next())[0];
-
   const valuesAndDescriptions = React.useState<Array<[string, string]>>(
     (() => {
       const realizedValuesAndDescriptions = new Array<[string, string]>();
@@ -33,32 +31,25 @@ export function EnumerationFieldRequired<EnumT extends number>(
   )[0];
 
   return (
-    <li>
-      <div className="aas-field">
-        <span className="aas-label">
-          {props.label}<HelpLink helpUrl={props.helpUrl}/>:
-        </span>
-
-        <select
-          id={inputId}
-          defaultValue={props.selected.toString()}
-          onChange={
-            (event) => {
-              props.onChange(parseInt(event.target.value) as EnumT);
-            }
+    <NonCompositeField label={props.label} helpUrl={props.helpUrl} errors={props.errors}>
+      <select
+        defaultValue={props.selected.toString()}
+        onChange={
+          (event) => {
+            props.onChange(parseInt(event.target.value) as EnumT);
           }
-        >
-          {
-            valuesAndDescriptions.map((valueAndDescription => {
-              const [value, description] = valueAndDescription;
+        }
+      >
+        {
+          valuesAndDescriptions.map((valueAndDescription => {
+            const [value, description] = valueAndDescription;
 
-              return (
-                <option key={value} value={value}>{description}</option>
-              )
-            }))
-          }
-        </select>
-      </div>
-    </li>
+            return (
+              <option key={value} value={value}>{description}</option>
+            )
+          }))
+        }
+      </select>
+    </NonCompositeField>
   )
 }

--- a/src/components/fields/ListFieldOptional.tsx
+++ b/src/components/fields/ListFieldOptional.tsx
@@ -18,9 +18,43 @@ export function ListFieldOptional<ClassT extends aas.types.Class>(
     setItems: (items: Array<ClassT> | null) => void
   }
 ) {
+  // See: https://github.com/facebook/react/issues/14476#issuecomment-471199055
+  // and https://stackoverflow.com/questions/59467758/passing-array-to-useeffect-dependency-list
+  const itemsErrorSetVersions = (props.items !== null)
+    ? props.items
+      .map((item) => model.getErrorSet(item).versioning.version)
+      .join(",")
+    : "";
+
+  const descendantsWithErrorsVersions = (props.items !== null)
+    ? props.items
+      .map((item) => model.getDescendantsWithErrors(item).versioning.version)
+      .join(",")
+    : "";
+
+  const [hasErrors, setHasErrors] = React.useState(false);
+
+  React.useEffect(
+    () => {
+      setHasErrors(
+        props.items !== null &&
+        (
+          props.items.some((item) => model.getErrorSet(item).size === 0)
+          || props.items.some(
+            (item) => model.getDescendantsWithErrors(item).size === 0
+          )
+        )
+      )
+    },
+    [
+      itemsErrorSetVersions,
+      descendantsWithErrorsVersions
+    ]
+  )
+
   return (
     <li>
-      <span className="aas-label"
+      <span className={!hasErrors ? "aas-label" : "aas-label-with-errors"}
       >{props.label}<HelpLink helpUrl={props.helpUrl}/>:</span>
 
       <ul className="aas-list">

--- a/src/components/fields/ListItem.tsx
+++ b/src/components/fields/ListItem.tsx
@@ -1,6 +1,9 @@
 import * as aas from "@aas-core-works/aas-core3.0rc02-typescript";
 import * as React from 'react';
+import * as valtio from 'valtio';
 
+import * as enhancing from '../../enhancing.generated'
+import * as model from '../../model'
 import * as titling from '../../titling.generated'
 import * as fielding from '../instances/fielding.generated'
 
@@ -13,10 +16,36 @@ export function ListItem<ClassT extends aas.types.Class>(
     shiftRight: (() => void) | null
   }
 ) {
+  const errorSetVersioning = valtio.useSnapshot(
+    model.getErrorSet(props.instance).versioning
+  );
+
+  const descendantsWithErrorsVersioning = valtio.useSnapshot(
+    model.getDescendantsWithErrors(props.instance).versioning
+  );
+
+  const [hasErrors, setHasErrors] = React.useState(false);
+
+  React.useEffect(
+    () => {
+      setHasErrors(
+        model.getErrorSet(props.instance).size > 0
+        || model.getDescendantsWithErrors(props.instance).size > 0
+      );
+    },
+    [
+      errorSetVersioning.version,
+      descendantsWithErrorsVersioning.version,
+      props.instance
+    ]
+  )
+
   return (
     <li className="aas-instance">
       <details open>
-        <summary>
+        <summary
+          className={hasErrors ? "aas-list-item-with-errors" : ""}
+        >
           {titling.getTitle(props.snapInstance)}
 
           <button

--- a/src/components/fields/NonCompositeField.tsx
+++ b/src/components/fields/NonCompositeField.tsx
@@ -1,0 +1,36 @@
+import * as React from "react";
+
+import {HelpLink} from "./HelpLink";
+import {LocalErrors} from "../widgets";
+import * as enhancing from "../../enhancing.generated";
+
+/**
+ * Represent a field which does not entail any further model instances.
+ *
+ * @remarks
+ * Think of these fields as atomic and enumeration values.
+ *
+ * *Composite* fields are implemented differently as we have to deal with errors
+ * and behavior in a different manner from *non-composite* fields.
+ */
+export function NonCompositeField(
+  props: React.PropsWithChildren<{
+    label: string,
+    helpUrl: string | null,
+    errors: Array<enhancing.TimestampedError> | null
+  }>
+) {
+  const hasErrors = (props.errors !== null && props.errors.length > 0);
+
+  return (
+    <li>
+      <div className="aas-field">
+        <span className={!hasErrors ? "aas-label" : "aas-label-with-errors"}
+        >{props.label}<HelpLink helpUrl={props.helpUrl}/>:</span>
+
+        {props.children}
+      </div>
+      <LocalErrors errors={props.errors}/>
+    </li>
+  )
+}

--- a/src/components/fields/TextFieldOptional.tsx
+++ b/src/components/fields/TextFieldOptional.tsx
@@ -1,39 +1,31 @@
 import * as React from "react";
 
-import * as incrementalid from "../../incrementalid";
 import * as widgets from '../widgets'
+import * as enhancing from "../../enhancing.generated";
 
-import {HelpLink} from "./HelpLink";
+import {NonCompositeField} from "./NonCompositeField";
 
 export function TextFieldOptional(
   props: {
     label: string,
     helpUrl: string | null,
     value: string | null,
-    onChange: (value: string | null) => void
+    onChange: (value: string | null) => void,
+    errors: Array<enhancing.TimestampedError> | null
   }
 ) {
-  const inputId = React.useState(incrementalid.next())[0];
-
   return (
-    <li>
-      <div className="aas-field">
-        <span className="aas-label">
-          {props.label}<HelpLink helpUrl={props.helpUrl}/>:
-        </span>
-
-        <widgets.TextAreaAutoResized
-          id={inputId}
-          content={props.value === null ? "" : props.value}
-          onChange={(content: string) => {
-            if (content === "") {
-              props.onChange(null);
-            } else {
-              props.onChange(content);
-            }
-          }}
-        />
-      </div>
-    </li>
+    <NonCompositeField label={props.label} helpUrl={props.helpUrl} errors={props.errors}>
+      <widgets.TextAreaAutoResized
+        content={props.value === null ? "" : props.value}
+        onChange={(content: string) => {
+          if (content === "") {
+            props.onChange(null);
+          } else {
+            props.onChange(content);
+          }
+        }}
+      />
+    </NonCompositeField>
   )
 }

--- a/src/components/fields/TextFieldRequired.tsx
+++ b/src/components/fields/TextFieldRequired.tsx
@@ -1,33 +1,25 @@
 import * as React from "react";
 
-import * as incrementalid from "../../incrementalid";
+import * as enhancing from "../../enhancing.generated";
 import * as widgets from '../widgets'
 
-import {HelpLink} from "./HelpLink";
+import {NonCompositeField} from "./NonCompositeField";
 
 export function TextFieldRequired(
   props: {
     label: string,
     helpUrl: string | null,
     value: string,
-    onChange: (value: string) => void
+    onChange: (value: string) => void,
+    errors: Array<enhancing.TimestampedError> | null
   }
 ) {
-  const inputId = React.useState(incrementalid.next())[0];
-
   return (
-    <li className="aas-field">
-      <div className="aas-field">
-        <span className="aas-label">
-          {props.label}<HelpLink helpUrl={props.helpUrl}/>:
-        </span>
-
-        <widgets.TextAreaAutoResized
-          id={inputId}
-          content={props.value}
-          onChange={props.onChange}
-        />
-      </div>
-    </li>
+    <NonCompositeField label={props.label} helpUrl={props.helpUrl} errors={props.errors}>
+      <widgets.TextAreaAutoResized
+        content={props.value}
+        onChange={props.onChange}
+      />
+    </NonCompositeField>
   )
 }

--- a/src/components/instances/AdministrativeInformationFields.generated.tsx
+++ b/src/components/instances/AdministrativeInformationFields.generated.tsx
@@ -11,10 +11,15 @@
 
 import * as aas from "@aas-core-works/aas-core3.0rc02-typescript";
 import * as React from "react";
+import * as valtio from "valtio";
 
-import * as fields from '../fields';
-import * as help from './help.generated';
-import * as newinstancing from '../../newinstancing.generated';
+import * as enhancing from "../../enhancing.generated";
+import * as fields from "../fields";
+import * as help from "./help.generated";
+import * as model from "../../model";
+import * as newinstancing from "../../newinstancing.generated";
+import * as verification from "../../verification";
+import * as widgets from "../widgets";
 
 export function AdministrativeInformationFields(
   props: {
@@ -22,8 +27,54 @@ export function AdministrativeInformationFields(
     instance: aas.types.AdministrativeInformation,
   }
 ) {
+  const [instanceErrors, setInstanceErrors] = React.useState<
+    Array<enhancing.TimestampedError> | null>(null);
+
+  const [errorsForVersion, setErrorsForVersion] = React.useState<
+    Array<enhancing.TimestampedError> | null>(null);
+
+  const [errorsForRevision, setErrorsForRevision] = React.useState<
+    Array<enhancing.TimestampedError> | null>(null);
+
+  const snapErrorSetVersioning = valtio.useSnapshot(
+    model.getErrorSet(props.instance).versioning
+  );
+
+  React.useEffect(
+    () => {
+      const [
+        anotherInstanceErrors,
+        errorsByProperty
+      ] = verification.categorizeInstanceErrors(
+        model.getErrorSet(props.instance)
+      );
+
+      setInstanceErrors(anotherInstanceErrors);
+
+      const anotherErrorsForVersion =
+        errorsByProperty.get("version");
+      setErrorsForVersion(
+        anotherErrorsForVersion === undefined
+          ? null
+          : anotherErrorsForVersion
+      );
+
+      const anotherErrorsForRevision =
+        errorsByProperty.get("revision");
+      setErrorsForRevision(
+        anotherErrorsForRevision === undefined
+          ? null
+          : anotherErrorsForRevision
+      );
+    },
+    [
+      snapErrorSetVersioning,
+      props.instance
+    ]
+  );
   return (
     <>
+    <widgets.LocalErrors errors={instanceErrors} />
       <fields.ListFieldOptional<aas.types.EmbeddedDataSpecification>
         label="Embedded data specifications"
         helpUrl={
@@ -58,6 +109,7 @@ export function AdministrativeInformationFields(
             props.instance.version = value;
           }
         }
+        errors={errorsForVersion}
       />
 
       <fields.TextFieldOptional
@@ -71,6 +123,7 @@ export function AdministrativeInformationFields(
             props.instance.revision = value;
           }
         }
+        errors={errorsForRevision}
       />
     </>
   )

--- a/src/components/instances/AnnotatedRelationshipElementFields.generated.tsx
+++ b/src/components/instances/AnnotatedRelationshipElementFields.generated.tsx
@@ -11,10 +11,15 @@
 
 import * as aas from "@aas-core-works/aas-core3.0rc02-typescript";
 import * as React from "react";
+import * as valtio from "valtio";
 
-import * as fields from '../fields';
-import * as help from './help.generated';
-import * as newinstancing from '../../newinstancing.generated';
+import * as enhancing from "../../enhancing.generated";
+import * as fields from "../fields";
+import * as help from "./help.generated";
+import * as model from "../../model";
+import * as newinstancing from "../../newinstancing.generated";
+import * as verification from "../../verification";
+import * as widgets from "../widgets";
 
 export function AnnotatedRelationshipElementFields(
   props: {
@@ -22,8 +27,76 @@ export function AnnotatedRelationshipElementFields(
     instance: aas.types.AnnotatedRelationshipElement,
   }
 ) {
+  const [instanceErrors, setInstanceErrors] = React.useState<
+    Array<enhancing.TimestampedError> | null>(null);
+
+  const [errorsForCategory, setErrorsForCategory] = React.useState<
+    Array<enhancing.TimestampedError> | null>(null);
+
+  const [errorsForIdShort, setErrorsForIdShort] = React.useState<
+    Array<enhancing.TimestampedError> | null>(null);
+
+  const [errorsForChecksum, setErrorsForChecksum] = React.useState<
+    Array<enhancing.TimestampedError> | null>(null);
+
+  const [errorsForKind, setErrorsForKind] = React.useState<
+    Array<enhancing.TimestampedError> | null>(null);
+
+  const snapErrorSetVersioning = valtio.useSnapshot(
+    model.getErrorSet(props.instance).versioning
+  );
+
+  React.useEffect(
+    () => {
+      const [
+        anotherInstanceErrors,
+        errorsByProperty
+      ] = verification.categorizeInstanceErrors(
+        model.getErrorSet(props.instance)
+      );
+
+      setInstanceErrors(anotherInstanceErrors);
+
+      const anotherErrorsForCategory =
+        errorsByProperty.get("category");
+      setErrorsForCategory(
+        anotherErrorsForCategory === undefined
+          ? null
+          : anotherErrorsForCategory
+      );
+
+      const anotherErrorsForIdShort =
+        errorsByProperty.get("idShort");
+      setErrorsForIdShort(
+        anotherErrorsForIdShort === undefined
+          ? null
+          : anotherErrorsForIdShort
+      );
+
+      const anotherErrorsForChecksum =
+        errorsByProperty.get("checksum");
+      setErrorsForChecksum(
+        anotherErrorsForChecksum === undefined
+          ? null
+          : anotherErrorsForChecksum
+      );
+
+      const anotherErrorsForKind =
+        errorsByProperty.get("kind");
+      setErrorsForKind(
+        anotherErrorsForKind === undefined
+          ? null
+          : anotherErrorsForKind
+      );
+    },
+    [
+      snapErrorSetVersioning,
+      props.instance
+    ]
+  );
   return (
     <>
+    <widgets.LocalErrors errors={instanceErrors} />
       <fields.ListFieldOptional<aas.types.Extension>
         label="Extensions"
         helpUrl={
@@ -58,6 +131,7 @@ export function AnnotatedRelationshipElementFields(
             props.instance.category = value;
           }
         }
+        errors={errorsForCategory}
       />
 
       <fields.TextFieldOptional
@@ -71,6 +145,7 @@ export function AnnotatedRelationshipElementFields(
             props.instance.idShort = value;
           }
         }
+        errors={errorsForIdShort}
       />
 
       <fields.ListFieldOptional<aas.types.LangString>
@@ -130,6 +205,7 @@ export function AnnotatedRelationshipElementFields(
             props.instance.checksum = value;
           }
         }
+        errors={errorsForChecksum}
       />
 
       <fields.EnumerationFieldOptional
@@ -145,6 +221,7 @@ export function AnnotatedRelationshipElementFields(
             props.instance.kind = value;
           }
         }
+        errors={errorsForKind}
       />
 
       <fields.EmbeddedInstanceOptional<aas.types.Reference>

--- a/src/components/instances/AssetAdministrationShellFields.generated.tsx
+++ b/src/components/instances/AssetAdministrationShellFields.generated.tsx
@@ -11,10 +11,15 @@
 
 import * as aas from "@aas-core-works/aas-core3.0rc02-typescript";
 import * as React from "react";
+import * as valtio from "valtio";
 
-import * as fields from '../fields';
-import * as help from './help.generated';
-import * as newinstancing from '../../newinstancing.generated';
+import * as enhancing from "../../enhancing.generated";
+import * as fields from "../fields";
+import * as help from "./help.generated";
+import * as model from "../../model";
+import * as newinstancing from "../../newinstancing.generated";
+import * as verification from "../../verification";
+import * as widgets from "../widgets";
 
 export function AssetAdministrationShellFields(
   props: {
@@ -22,8 +27,76 @@ export function AssetAdministrationShellFields(
     instance: aas.types.AssetAdministrationShell,
   }
 ) {
+  const [instanceErrors, setInstanceErrors] = React.useState<
+    Array<enhancing.TimestampedError> | null>(null);
+
+  const [errorsForCategory, setErrorsForCategory] = React.useState<
+    Array<enhancing.TimestampedError> | null>(null);
+
+  const [errorsForIdShort, setErrorsForIdShort] = React.useState<
+    Array<enhancing.TimestampedError> | null>(null);
+
+  const [errorsForChecksum, setErrorsForChecksum] = React.useState<
+    Array<enhancing.TimestampedError> | null>(null);
+
+  const [errorsForId, setErrorsForId] = React.useState<
+    Array<enhancing.TimestampedError> | null>(null);
+
+  const snapErrorSetVersioning = valtio.useSnapshot(
+    model.getErrorSet(props.instance).versioning
+  );
+
+  React.useEffect(
+    () => {
+      const [
+        anotherInstanceErrors,
+        errorsByProperty
+      ] = verification.categorizeInstanceErrors(
+        model.getErrorSet(props.instance)
+      );
+
+      setInstanceErrors(anotherInstanceErrors);
+
+      const anotherErrorsForCategory =
+        errorsByProperty.get("category");
+      setErrorsForCategory(
+        anotherErrorsForCategory === undefined
+          ? null
+          : anotherErrorsForCategory
+      );
+
+      const anotherErrorsForIdShort =
+        errorsByProperty.get("idShort");
+      setErrorsForIdShort(
+        anotherErrorsForIdShort === undefined
+          ? null
+          : anotherErrorsForIdShort
+      );
+
+      const anotherErrorsForChecksum =
+        errorsByProperty.get("checksum");
+      setErrorsForChecksum(
+        anotherErrorsForChecksum === undefined
+          ? null
+          : anotherErrorsForChecksum
+      );
+
+      const anotherErrorsForId =
+        errorsByProperty.get("id");
+      setErrorsForId(
+        anotherErrorsForId === undefined
+          ? null
+          : anotherErrorsForId
+      );
+    },
+    [
+      snapErrorSetVersioning,
+      props.instance
+    ]
+  );
   return (
     <>
+    <widgets.LocalErrors errors={instanceErrors} />
       <fields.ListFieldOptional<aas.types.Extension>
         label="Extensions"
         helpUrl={
@@ -58,6 +131,7 @@ export function AssetAdministrationShellFields(
             props.instance.category = value;
           }
         }
+        errors={errorsForCategory}
       />
 
       <fields.TextFieldOptional
@@ -71,6 +145,7 @@ export function AssetAdministrationShellFields(
             props.instance.idShort = value;
           }
         }
+        errors={errorsForIdShort}
       />
 
       <fields.ListFieldOptional<aas.types.LangString>
@@ -130,6 +205,7 @@ export function AssetAdministrationShellFields(
             props.instance.checksum = value;
           }
         }
+        errors={errorsForChecksum}
       />
 
       <fields.EmbeddedInstanceOptional<aas.types.AdministrativeInformation>
@@ -166,6 +242,7 @@ export function AssetAdministrationShellFields(
             props.instance.id = value;
           }
         }
+        errors={errorsForId}
       />
 
       <fields.ListFieldOptional<aas.types.EmbeddedDataSpecification>

--- a/src/components/instances/AssetInformationFields.generated.tsx
+++ b/src/components/instances/AssetInformationFields.generated.tsx
@@ -11,10 +11,15 @@
 
 import * as aas from "@aas-core-works/aas-core3.0rc02-typescript";
 import * as React from "react";
+import * as valtio from "valtio";
 
-import * as fields from '../fields';
-import * as help from './help.generated';
-import * as newinstancing from '../../newinstancing.generated';
+import * as enhancing from "../../enhancing.generated";
+import * as fields from "../fields";
+import * as help from "./help.generated";
+import * as model from "../../model";
+import * as newinstancing from "../../newinstancing.generated";
+import * as verification from "../../verification";
+import * as widgets from "../widgets";
 
 export function AssetInformationFields(
   props: {
@@ -22,8 +27,43 @@ export function AssetInformationFields(
     instance: aas.types.AssetInformation,
   }
 ) {
+  const [instanceErrors, setInstanceErrors] = React.useState<
+    Array<enhancing.TimestampedError> | null>(null);
+
+  const [errorsForAssetKind, setErrorsForAssetKind] = React.useState<
+    Array<enhancing.TimestampedError> | null>(null);
+
+  const snapErrorSetVersioning = valtio.useSnapshot(
+    model.getErrorSet(props.instance).versioning
+  );
+
+  React.useEffect(
+    () => {
+      const [
+        anotherInstanceErrors,
+        errorsByProperty
+      ] = verification.categorizeInstanceErrors(
+        model.getErrorSet(props.instance)
+      );
+
+      setInstanceErrors(anotherInstanceErrors);
+
+      const anotherErrorsForAssetKind =
+        errorsByProperty.get("assetKind");
+      setErrorsForAssetKind(
+        anotherErrorsForAssetKind === undefined
+          ? null
+          : anotherErrorsForAssetKind
+      );
+    },
+    [
+      snapErrorSetVersioning,
+      props.instance
+    ]
+  );
   return (
     <>
+    <widgets.LocalErrors errors={instanceErrors} />
       <fields.EnumerationFieldRequired
         label="Asset kind"
         helpUrl={
@@ -37,6 +77,7 @@ export function AssetInformationFields(
             props.instance.assetKind = value;
           }
         }
+        errors={errorsForAssetKind}
       />
 
       <fields.EmbeddedInstanceOptional<aas.types.Reference>

--- a/src/components/instances/BasicEventElementFields.generated.tsx
+++ b/src/components/instances/BasicEventElementFields.generated.tsx
@@ -11,10 +11,15 @@
 
 import * as aas from "@aas-core-works/aas-core3.0rc02-typescript";
 import * as React from "react";
+import * as valtio from "valtio";
 
-import * as fields from '../fields';
-import * as help from './help.generated';
-import * as newinstancing from '../../newinstancing.generated';
+import * as enhancing from "../../enhancing.generated";
+import * as fields from "../fields";
+import * as help from "./help.generated";
+import * as model from "../../model";
+import * as newinstancing from "../../newinstancing.generated";
+import * as verification from "../../verification";
+import * as widgets from "../widgets";
 
 export function BasicEventElementFields(
   props: {
@@ -22,8 +27,142 @@ export function BasicEventElementFields(
     instance: aas.types.BasicEventElement,
   }
 ) {
+  const [instanceErrors, setInstanceErrors] = React.useState<
+    Array<enhancing.TimestampedError> | null>(null);
+
+  const [errorsForCategory, setErrorsForCategory] = React.useState<
+    Array<enhancing.TimestampedError> | null>(null);
+
+  const [errorsForIdShort, setErrorsForIdShort] = React.useState<
+    Array<enhancing.TimestampedError> | null>(null);
+
+  const [errorsForChecksum, setErrorsForChecksum] = React.useState<
+    Array<enhancing.TimestampedError> | null>(null);
+
+  const [errorsForKind, setErrorsForKind] = React.useState<
+    Array<enhancing.TimestampedError> | null>(null);
+
+  const [errorsForDirection, setErrorsForDirection] = React.useState<
+    Array<enhancing.TimestampedError> | null>(null);
+
+  const [errorsForState, setErrorsForState] = React.useState<
+    Array<enhancing.TimestampedError> | null>(null);
+
+  const [errorsForMessageTopic, setErrorsForMessageTopic] = React.useState<
+    Array<enhancing.TimestampedError> | null>(null);
+
+  const [errorsForLastUpdate, setErrorsForLastUpdate] = React.useState<
+    Array<enhancing.TimestampedError> | null>(null);
+
+  const [errorsForMinInterval, setErrorsForMinInterval] = React.useState<
+    Array<enhancing.TimestampedError> | null>(null);
+
+  const [errorsForMaxInterval, setErrorsForMaxInterval] = React.useState<
+    Array<enhancing.TimestampedError> | null>(null);
+
+  const snapErrorSetVersioning = valtio.useSnapshot(
+    model.getErrorSet(props.instance).versioning
+  );
+
+  React.useEffect(
+    () => {
+      const [
+        anotherInstanceErrors,
+        errorsByProperty
+      ] = verification.categorizeInstanceErrors(
+        model.getErrorSet(props.instance)
+      );
+
+      setInstanceErrors(anotherInstanceErrors);
+
+      const anotherErrorsForCategory =
+        errorsByProperty.get("category");
+      setErrorsForCategory(
+        anotherErrorsForCategory === undefined
+          ? null
+          : anotherErrorsForCategory
+      );
+
+      const anotherErrorsForIdShort =
+        errorsByProperty.get("idShort");
+      setErrorsForIdShort(
+        anotherErrorsForIdShort === undefined
+          ? null
+          : anotherErrorsForIdShort
+      );
+
+      const anotherErrorsForChecksum =
+        errorsByProperty.get("checksum");
+      setErrorsForChecksum(
+        anotherErrorsForChecksum === undefined
+          ? null
+          : anotherErrorsForChecksum
+      );
+
+      const anotherErrorsForKind =
+        errorsByProperty.get("kind");
+      setErrorsForKind(
+        anotherErrorsForKind === undefined
+          ? null
+          : anotherErrorsForKind
+      );
+
+      const anotherErrorsForDirection =
+        errorsByProperty.get("direction");
+      setErrorsForDirection(
+        anotherErrorsForDirection === undefined
+          ? null
+          : anotherErrorsForDirection
+      );
+
+      const anotherErrorsForState =
+        errorsByProperty.get("state");
+      setErrorsForState(
+        anotherErrorsForState === undefined
+          ? null
+          : anotherErrorsForState
+      );
+
+      const anotherErrorsForMessageTopic =
+        errorsByProperty.get("messageTopic");
+      setErrorsForMessageTopic(
+        anotherErrorsForMessageTopic === undefined
+          ? null
+          : anotherErrorsForMessageTopic
+      );
+
+      const anotherErrorsForLastUpdate =
+        errorsByProperty.get("lastUpdate");
+      setErrorsForLastUpdate(
+        anotherErrorsForLastUpdate === undefined
+          ? null
+          : anotherErrorsForLastUpdate
+      );
+
+      const anotherErrorsForMinInterval =
+        errorsByProperty.get("minInterval");
+      setErrorsForMinInterval(
+        anotherErrorsForMinInterval === undefined
+          ? null
+          : anotherErrorsForMinInterval
+      );
+
+      const anotherErrorsForMaxInterval =
+        errorsByProperty.get("maxInterval");
+      setErrorsForMaxInterval(
+        anotherErrorsForMaxInterval === undefined
+          ? null
+          : anotherErrorsForMaxInterval
+      );
+    },
+    [
+      snapErrorSetVersioning,
+      props.instance
+    ]
+  );
   return (
     <>
+    <widgets.LocalErrors errors={instanceErrors} />
       <fields.ListFieldOptional<aas.types.Extension>
         label="Extensions"
         helpUrl={
@@ -58,6 +197,7 @@ export function BasicEventElementFields(
             props.instance.category = value;
           }
         }
+        errors={errorsForCategory}
       />
 
       <fields.TextFieldOptional
@@ -71,6 +211,7 @@ export function BasicEventElementFields(
             props.instance.idShort = value;
           }
         }
+        errors={errorsForIdShort}
       />
 
       <fields.ListFieldOptional<aas.types.LangString>
@@ -130,6 +271,7 @@ export function BasicEventElementFields(
             props.instance.checksum = value;
           }
         }
+        errors={errorsForChecksum}
       />
 
       <fields.EnumerationFieldOptional
@@ -145,6 +287,7 @@ export function BasicEventElementFields(
             props.instance.kind = value;
           }
         }
+        errors={errorsForKind}
       />
 
       <fields.EmbeddedInstanceOptional<aas.types.Reference>
@@ -275,6 +418,7 @@ export function BasicEventElementFields(
             props.instance.direction = value;
           }
         }
+        errors={errorsForDirection}
       />
 
       <fields.EnumerationFieldRequired
@@ -290,6 +434,7 @@ export function BasicEventElementFields(
             props.instance.state = value;
           }
         }
+        errors={errorsForState}
       />
 
       <fields.TextFieldOptional
@@ -303,6 +448,7 @@ export function BasicEventElementFields(
             props.instance.messageTopic = value;
           }
         }
+        errors={errorsForMessageTopic}
       />
 
       <fields.EmbeddedInstanceOptional<aas.types.Reference>
@@ -339,6 +485,7 @@ export function BasicEventElementFields(
             props.instance.lastUpdate = value;
           }
         }
+        errors={errorsForLastUpdate}
       />
 
       <fields.TextFieldOptional
@@ -352,6 +499,7 @@ export function BasicEventElementFields(
             props.instance.minInterval = value;
           }
         }
+        errors={errorsForMinInterval}
       />
 
       <fields.TextFieldOptional
@@ -365,6 +513,7 @@ export function BasicEventElementFields(
             props.instance.maxInterval = value;
           }
         }
+        errors={errorsForMaxInterval}
       />
     </>
   )

--- a/src/components/instances/BlobFields.generated.tsx
+++ b/src/components/instances/BlobFields.generated.tsx
@@ -11,10 +11,15 @@
 
 import * as aas from "@aas-core-works/aas-core3.0rc02-typescript";
 import * as React from "react";
+import * as valtio from "valtio";
 
-import * as fields from '../fields';
-import * as help from './help.generated';
-import * as newinstancing from '../../newinstancing.generated';
+import * as enhancing from "../../enhancing.generated";
+import * as fields from "../fields";
+import * as help from "./help.generated";
+import * as model from "../../model";
+import * as newinstancing from "../../newinstancing.generated";
+import * as verification from "../../verification";
+import * as widgets from "../widgets";
 
 export function BlobFields(
   props: {
@@ -22,8 +27,98 @@ export function BlobFields(
     instance: aas.types.Blob,
   }
 ) {
+  const [instanceErrors, setInstanceErrors] = React.useState<
+    Array<enhancing.TimestampedError> | null>(null);
+
+  const [errorsForCategory, setErrorsForCategory] = React.useState<
+    Array<enhancing.TimestampedError> | null>(null);
+
+  const [errorsForIdShort, setErrorsForIdShort] = React.useState<
+    Array<enhancing.TimestampedError> | null>(null);
+
+  const [errorsForChecksum, setErrorsForChecksum] = React.useState<
+    Array<enhancing.TimestampedError> | null>(null);
+
+  const [errorsForKind, setErrorsForKind] = React.useState<
+    Array<enhancing.TimestampedError> | null>(null);
+
+  const [errorsForValue, setErrorsForValue] = React.useState<
+    Array<enhancing.TimestampedError> | null>(null);
+
+  const [errorsForContentType, setErrorsForContentType] = React.useState<
+    Array<enhancing.TimestampedError> | null>(null);
+
+  const snapErrorSetVersioning = valtio.useSnapshot(
+    model.getErrorSet(props.instance).versioning
+  );
+
+  React.useEffect(
+    () => {
+      const [
+        anotherInstanceErrors,
+        errorsByProperty
+      ] = verification.categorizeInstanceErrors(
+        model.getErrorSet(props.instance)
+      );
+
+      setInstanceErrors(anotherInstanceErrors);
+
+      const anotherErrorsForCategory =
+        errorsByProperty.get("category");
+      setErrorsForCategory(
+        anotherErrorsForCategory === undefined
+          ? null
+          : anotherErrorsForCategory
+      );
+
+      const anotherErrorsForIdShort =
+        errorsByProperty.get("idShort");
+      setErrorsForIdShort(
+        anotherErrorsForIdShort === undefined
+          ? null
+          : anotherErrorsForIdShort
+      );
+
+      const anotherErrorsForChecksum =
+        errorsByProperty.get("checksum");
+      setErrorsForChecksum(
+        anotherErrorsForChecksum === undefined
+          ? null
+          : anotherErrorsForChecksum
+      );
+
+      const anotherErrorsForKind =
+        errorsByProperty.get("kind");
+      setErrorsForKind(
+        anotherErrorsForKind === undefined
+          ? null
+          : anotherErrorsForKind
+      );
+
+      const anotherErrorsForValue =
+        errorsByProperty.get("value");
+      setErrorsForValue(
+        anotherErrorsForValue === undefined
+          ? null
+          : anotherErrorsForValue
+      );
+
+      const anotherErrorsForContentType =
+        errorsByProperty.get("contentType");
+      setErrorsForContentType(
+        anotherErrorsForContentType === undefined
+          ? null
+          : anotherErrorsForContentType
+      );
+    },
+    [
+      snapErrorSetVersioning,
+      props.instance
+    ]
+  );
   return (
     <>
+    <widgets.LocalErrors errors={instanceErrors} />
       <fields.ListFieldOptional<aas.types.Extension>
         label="Extensions"
         helpUrl={
@@ -58,6 +153,7 @@ export function BlobFields(
             props.instance.category = value;
           }
         }
+        errors={errorsForCategory}
       />
 
       <fields.TextFieldOptional
@@ -71,6 +167,7 @@ export function BlobFields(
             props.instance.idShort = value;
           }
         }
+        errors={errorsForIdShort}
       />
 
       <fields.ListFieldOptional<aas.types.LangString>
@@ -130,6 +227,7 @@ export function BlobFields(
             props.instance.checksum = value;
           }
         }
+        errors={errorsForChecksum}
       />
 
       <fields.EnumerationFieldOptional
@@ -145,6 +243,7 @@ export function BlobFields(
             props.instance.kind = value;
           }
         }
+        errors={errorsForKind}
       />
 
       <fields.EmbeddedInstanceOptional<aas.types.Reference>
@@ -251,6 +350,7 @@ export function BlobFields(
           }
         }
         contentType={props.snapInstance.contentType}
+        errors={errorsForValue}
       />
 
       <fields.TextFieldRequired
@@ -264,6 +364,7 @@ export function BlobFields(
             props.instance.contentType = value;
           }
         }
+        errors={errorsForContentType}
       />
     </>
   )

--- a/src/components/instances/CapabilityFields.generated.tsx
+++ b/src/components/instances/CapabilityFields.generated.tsx
@@ -11,10 +11,15 @@
 
 import * as aas from "@aas-core-works/aas-core3.0rc02-typescript";
 import * as React from "react";
+import * as valtio from "valtio";
 
-import * as fields from '../fields';
-import * as help from './help.generated';
-import * as newinstancing from '../../newinstancing.generated';
+import * as enhancing from "../../enhancing.generated";
+import * as fields from "../fields";
+import * as help from "./help.generated";
+import * as model from "../../model";
+import * as newinstancing from "../../newinstancing.generated";
+import * as verification from "../../verification";
+import * as widgets from "../widgets";
 
 export function CapabilityFields(
   props: {
@@ -22,8 +27,76 @@ export function CapabilityFields(
     instance: aas.types.Capability,
   }
 ) {
+  const [instanceErrors, setInstanceErrors] = React.useState<
+    Array<enhancing.TimestampedError> | null>(null);
+
+  const [errorsForCategory, setErrorsForCategory] = React.useState<
+    Array<enhancing.TimestampedError> | null>(null);
+
+  const [errorsForIdShort, setErrorsForIdShort] = React.useState<
+    Array<enhancing.TimestampedError> | null>(null);
+
+  const [errorsForChecksum, setErrorsForChecksum] = React.useState<
+    Array<enhancing.TimestampedError> | null>(null);
+
+  const [errorsForKind, setErrorsForKind] = React.useState<
+    Array<enhancing.TimestampedError> | null>(null);
+
+  const snapErrorSetVersioning = valtio.useSnapshot(
+    model.getErrorSet(props.instance).versioning
+  );
+
+  React.useEffect(
+    () => {
+      const [
+        anotherInstanceErrors,
+        errorsByProperty
+      ] = verification.categorizeInstanceErrors(
+        model.getErrorSet(props.instance)
+      );
+
+      setInstanceErrors(anotherInstanceErrors);
+
+      const anotherErrorsForCategory =
+        errorsByProperty.get("category");
+      setErrorsForCategory(
+        anotherErrorsForCategory === undefined
+          ? null
+          : anotherErrorsForCategory
+      );
+
+      const anotherErrorsForIdShort =
+        errorsByProperty.get("idShort");
+      setErrorsForIdShort(
+        anotherErrorsForIdShort === undefined
+          ? null
+          : anotherErrorsForIdShort
+      );
+
+      const anotherErrorsForChecksum =
+        errorsByProperty.get("checksum");
+      setErrorsForChecksum(
+        anotherErrorsForChecksum === undefined
+          ? null
+          : anotherErrorsForChecksum
+      );
+
+      const anotherErrorsForKind =
+        errorsByProperty.get("kind");
+      setErrorsForKind(
+        anotherErrorsForKind === undefined
+          ? null
+          : anotherErrorsForKind
+      );
+    },
+    [
+      snapErrorSetVersioning,
+      props.instance
+    ]
+  );
   return (
     <>
+    <widgets.LocalErrors errors={instanceErrors} />
       <fields.ListFieldOptional<aas.types.Extension>
         label="Extensions"
         helpUrl={
@@ -58,6 +131,7 @@ export function CapabilityFields(
             props.instance.category = value;
           }
         }
+        errors={errorsForCategory}
       />
 
       <fields.TextFieldOptional
@@ -71,6 +145,7 @@ export function CapabilityFields(
             props.instance.idShort = value;
           }
         }
+        errors={errorsForIdShort}
       />
 
       <fields.ListFieldOptional<aas.types.LangString>
@@ -130,6 +205,7 @@ export function CapabilityFields(
             props.instance.checksum = value;
           }
         }
+        errors={errorsForChecksum}
       />
 
       <fields.EnumerationFieldOptional
@@ -145,6 +221,7 @@ export function CapabilityFields(
             props.instance.kind = value;
           }
         }
+        errors={errorsForKind}
       />
 
       <fields.EmbeddedInstanceOptional<aas.types.Reference>

--- a/src/components/instances/ConceptDescriptionFields.generated.tsx
+++ b/src/components/instances/ConceptDescriptionFields.generated.tsx
@@ -11,10 +11,15 @@
 
 import * as aas from "@aas-core-works/aas-core3.0rc02-typescript";
 import * as React from "react";
+import * as valtio from "valtio";
 
-import * as fields from '../fields';
-import * as help from './help.generated';
-import * as newinstancing from '../../newinstancing.generated';
+import * as enhancing from "../../enhancing.generated";
+import * as fields from "../fields";
+import * as help from "./help.generated";
+import * as model from "../../model";
+import * as newinstancing from "../../newinstancing.generated";
+import * as verification from "../../verification";
+import * as widgets from "../widgets";
 
 export function ConceptDescriptionFields(
   props: {
@@ -22,8 +27,76 @@ export function ConceptDescriptionFields(
     instance: aas.types.ConceptDescription,
   }
 ) {
+  const [instanceErrors, setInstanceErrors] = React.useState<
+    Array<enhancing.TimestampedError> | null>(null);
+
+  const [errorsForCategory, setErrorsForCategory] = React.useState<
+    Array<enhancing.TimestampedError> | null>(null);
+
+  const [errorsForIdShort, setErrorsForIdShort] = React.useState<
+    Array<enhancing.TimestampedError> | null>(null);
+
+  const [errorsForChecksum, setErrorsForChecksum] = React.useState<
+    Array<enhancing.TimestampedError> | null>(null);
+
+  const [errorsForId, setErrorsForId] = React.useState<
+    Array<enhancing.TimestampedError> | null>(null);
+
+  const snapErrorSetVersioning = valtio.useSnapshot(
+    model.getErrorSet(props.instance).versioning
+  );
+
+  React.useEffect(
+    () => {
+      const [
+        anotherInstanceErrors,
+        errorsByProperty
+      ] = verification.categorizeInstanceErrors(
+        model.getErrorSet(props.instance)
+      );
+
+      setInstanceErrors(anotherInstanceErrors);
+
+      const anotherErrorsForCategory =
+        errorsByProperty.get("category");
+      setErrorsForCategory(
+        anotherErrorsForCategory === undefined
+          ? null
+          : anotherErrorsForCategory
+      );
+
+      const anotherErrorsForIdShort =
+        errorsByProperty.get("idShort");
+      setErrorsForIdShort(
+        anotherErrorsForIdShort === undefined
+          ? null
+          : anotherErrorsForIdShort
+      );
+
+      const anotherErrorsForChecksum =
+        errorsByProperty.get("checksum");
+      setErrorsForChecksum(
+        anotherErrorsForChecksum === undefined
+          ? null
+          : anotherErrorsForChecksum
+      );
+
+      const anotherErrorsForId =
+        errorsByProperty.get("id");
+      setErrorsForId(
+        anotherErrorsForId === undefined
+          ? null
+          : anotherErrorsForId
+      );
+    },
+    [
+      snapErrorSetVersioning,
+      props.instance
+    ]
+  );
   return (
     <>
+    <widgets.LocalErrors errors={instanceErrors} />
       <fields.ListFieldOptional<aas.types.Extension>
         label="Extensions"
         helpUrl={
@@ -58,6 +131,7 @@ export function ConceptDescriptionFields(
             props.instance.category = value;
           }
         }
+        errors={errorsForCategory}
       />
 
       <fields.TextFieldOptional
@@ -71,6 +145,7 @@ export function ConceptDescriptionFields(
             props.instance.idShort = value;
           }
         }
+        errors={errorsForIdShort}
       />
 
       <fields.ListFieldOptional<aas.types.LangString>
@@ -130,6 +205,7 @@ export function ConceptDescriptionFields(
             props.instance.checksum = value;
           }
         }
+        errors={errorsForChecksum}
       />
 
       <fields.EmbeddedInstanceOptional<aas.types.AdministrativeInformation>
@@ -166,6 +242,7 @@ export function ConceptDescriptionFields(
             props.instance.id = value;
           }
         }
+        errors={errorsForId}
       />
 
       <fields.ListFieldOptional<aas.types.EmbeddedDataSpecification>

--- a/src/components/instances/DataSpecificationIec61360Fields.generated.tsx
+++ b/src/components/instances/DataSpecificationIec61360Fields.generated.tsx
@@ -11,10 +11,15 @@
 
 import * as aas from "@aas-core-works/aas-core3.0rc02-typescript";
 import * as React from "react";
+import * as valtio from "valtio";
 
-import * as fields from '../fields';
-import * as help from './help.generated';
-import * as newinstancing from '../../newinstancing.generated';
+import * as enhancing from "../../enhancing.generated";
+import * as fields from "../fields";
+import * as help from "./help.generated";
+import * as model from "../../model";
+import * as newinstancing from "../../newinstancing.generated";
+import * as verification from "../../verification";
+import * as widgets from "../widgets";
 
 export function DataSpecificationIec61360Fields(
   props: {
@@ -22,8 +27,109 @@ export function DataSpecificationIec61360Fields(
     instance: aas.types.DataSpecificationIec61360,
   }
 ) {
+  const [instanceErrors, setInstanceErrors] = React.useState<
+    Array<enhancing.TimestampedError> | null>(null);
+
+  const [errorsForUnit, setErrorsForUnit] = React.useState<
+    Array<enhancing.TimestampedError> | null>(null);
+
+  const [errorsForSourceOfDefinition, setErrorsForSourceOfDefinition] = React.useState<
+    Array<enhancing.TimestampedError> | null>(null);
+
+  const [errorsForSymbol, setErrorsForSymbol] = React.useState<
+    Array<enhancing.TimestampedError> | null>(null);
+
+  const [errorsForDataType, setErrorsForDataType] = React.useState<
+    Array<enhancing.TimestampedError> | null>(null);
+
+  const [errorsForValueFormat, setErrorsForValueFormat] = React.useState<
+    Array<enhancing.TimestampedError> | null>(null);
+
+  const [errorsForValue, setErrorsForValue] = React.useState<
+    Array<enhancing.TimestampedError> | null>(null);
+
+  const [errorsForLevelType, setErrorsForLevelType] = React.useState<
+    Array<enhancing.TimestampedError> | null>(null);
+
+  const snapErrorSetVersioning = valtio.useSnapshot(
+    model.getErrorSet(props.instance).versioning
+  );
+
+  React.useEffect(
+    () => {
+      const [
+        anotherInstanceErrors,
+        errorsByProperty
+      ] = verification.categorizeInstanceErrors(
+        model.getErrorSet(props.instance)
+      );
+
+      setInstanceErrors(anotherInstanceErrors);
+
+      const anotherErrorsForUnit =
+        errorsByProperty.get("unit");
+      setErrorsForUnit(
+        anotherErrorsForUnit === undefined
+          ? null
+          : anotherErrorsForUnit
+      );
+
+      const anotherErrorsForSourceOfDefinition =
+        errorsByProperty.get("sourceOfDefinition");
+      setErrorsForSourceOfDefinition(
+        anotherErrorsForSourceOfDefinition === undefined
+          ? null
+          : anotherErrorsForSourceOfDefinition
+      );
+
+      const anotherErrorsForSymbol =
+        errorsByProperty.get("symbol");
+      setErrorsForSymbol(
+        anotherErrorsForSymbol === undefined
+          ? null
+          : anotherErrorsForSymbol
+      );
+
+      const anotherErrorsForDataType =
+        errorsByProperty.get("dataType");
+      setErrorsForDataType(
+        anotherErrorsForDataType === undefined
+          ? null
+          : anotherErrorsForDataType
+      );
+
+      const anotherErrorsForValueFormat =
+        errorsByProperty.get("valueFormat");
+      setErrorsForValueFormat(
+        anotherErrorsForValueFormat === undefined
+          ? null
+          : anotherErrorsForValueFormat
+      );
+
+      const anotherErrorsForValue =
+        errorsByProperty.get("value");
+      setErrorsForValue(
+        anotherErrorsForValue === undefined
+          ? null
+          : anotherErrorsForValue
+      );
+
+      const anotherErrorsForLevelType =
+        errorsByProperty.get("levelType");
+      setErrorsForLevelType(
+        anotherErrorsForLevelType === undefined
+          ? null
+          : anotherErrorsForLevelType
+      );
+    },
+    [
+      snapErrorSetVersioning,
+      props.instance
+    ]
+  );
   return (
     <>
+    <widgets.LocalErrors errors={instanceErrors} />
       <fields.ListFieldRequired<aas.types.LangString>
         label="Preferred name"
         helpUrl={
@@ -81,6 +187,7 @@ export function DataSpecificationIec61360Fields(
             props.instance.unit = value;
           }
         }
+        errors={errorsForUnit}
       />
 
       <fields.EmbeddedInstanceOptional<aas.types.Reference>
@@ -117,6 +224,7 @@ export function DataSpecificationIec61360Fields(
             props.instance.sourceOfDefinition = value;
           }
         }
+        errors={errorsForSourceOfDefinition}
       />
 
       <fields.TextFieldOptional
@@ -130,6 +238,7 @@ export function DataSpecificationIec61360Fields(
             props.instance.symbol = value;
           }
         }
+        errors={errorsForSymbol}
       />
 
       <fields.EnumerationFieldOptional
@@ -145,6 +254,7 @@ export function DataSpecificationIec61360Fields(
             props.instance.dataType = value;
           }
         }
+        errors={errorsForDataType}
       />
 
       <fields.ListFieldOptional<aas.types.LangString>
@@ -181,6 +291,7 @@ export function DataSpecificationIec61360Fields(
             props.instance.valueFormat = value;
           }
         }
+        errors={errorsForValueFormat}
       />
 
       <fields.EmbeddedInstanceOptional<aas.types.ValueList>
@@ -217,6 +328,7 @@ export function DataSpecificationIec61360Fields(
             props.instance.value = value;
           }
         }
+        errors={errorsForValue}
       />
 
       <fields.EnumerationFieldOptional
@@ -232,6 +344,7 @@ export function DataSpecificationIec61360Fields(
             props.instance.levelType = value;
           }
         }
+        errors={errorsForLevelType}
       />
     </>
   )

--- a/src/components/instances/DataSpecificationPhysicalUnitFields.generated.tsx
+++ b/src/components/instances/DataSpecificationPhysicalUnitFields.generated.tsx
@@ -11,10 +11,15 @@
 
 import * as aas from "@aas-core-works/aas-core3.0rc02-typescript";
 import * as React from "react";
+import * as valtio from "valtio";
 
-import * as fields from '../fields';
-import * as help from './help.generated';
-import * as newinstancing from '../../newinstancing.generated';
+import * as enhancing from "../../enhancing.generated";
+import * as fields from "../fields";
+import * as help from "./help.generated";
+import * as model from "../../model";
+import * as newinstancing from "../../newinstancing.generated";
+import * as verification from "../../verification";
+import * as widgets from "../widgets";
 
 export function DataSpecificationPhysicalUnitFields(
   props: {
@@ -22,8 +27,164 @@ export function DataSpecificationPhysicalUnitFields(
     instance: aas.types.DataSpecificationPhysicalUnit,
   }
 ) {
+  const [instanceErrors, setInstanceErrors] = React.useState<
+    Array<enhancing.TimestampedError> | null>(null);
+
+  const [errorsForUnitName, setErrorsForUnitName] = React.useState<
+    Array<enhancing.TimestampedError> | null>(null);
+
+  const [errorsForUnitSymbol, setErrorsForUnitSymbol] = React.useState<
+    Array<enhancing.TimestampedError> | null>(null);
+
+  const [errorsForSiNotation, setErrorsForSiNotation] = React.useState<
+    Array<enhancing.TimestampedError> | null>(null);
+
+  const [errorsForSiName, setErrorsForSiName] = React.useState<
+    Array<enhancing.TimestampedError> | null>(null);
+
+  const [errorsForDinNotation, setErrorsForDinNotation] = React.useState<
+    Array<enhancing.TimestampedError> | null>(null);
+
+  const [errorsForEceName, setErrorsForEceName] = React.useState<
+    Array<enhancing.TimestampedError> | null>(null);
+
+  const [errorsForEceCode, setErrorsForEceCode] = React.useState<
+    Array<enhancing.TimestampedError> | null>(null);
+
+  const [errorsForNistName, setErrorsForNistName] = React.useState<
+    Array<enhancing.TimestampedError> | null>(null);
+
+  const [errorsForSourceOfDefinition, setErrorsForSourceOfDefinition] = React.useState<
+    Array<enhancing.TimestampedError> | null>(null);
+
+  const [errorsForConversionFactor, setErrorsForConversionFactor] = React.useState<
+    Array<enhancing.TimestampedError> | null>(null);
+
+  const [errorsForRegistrationAuthorityId, setErrorsForRegistrationAuthorityId] = React.useState<
+    Array<enhancing.TimestampedError> | null>(null);
+
+  const [errorsForSupplier, setErrorsForSupplier] = React.useState<
+    Array<enhancing.TimestampedError> | null>(null);
+
+  const snapErrorSetVersioning = valtio.useSnapshot(
+    model.getErrorSet(props.instance).versioning
+  );
+
+  React.useEffect(
+    () => {
+      const [
+        anotherInstanceErrors,
+        errorsByProperty
+      ] = verification.categorizeInstanceErrors(
+        model.getErrorSet(props.instance)
+      );
+
+      setInstanceErrors(anotherInstanceErrors);
+
+      const anotherErrorsForUnitName =
+        errorsByProperty.get("unitName");
+      setErrorsForUnitName(
+        anotherErrorsForUnitName === undefined
+          ? null
+          : anotherErrorsForUnitName
+      );
+
+      const anotherErrorsForUnitSymbol =
+        errorsByProperty.get("unitSymbol");
+      setErrorsForUnitSymbol(
+        anotherErrorsForUnitSymbol === undefined
+          ? null
+          : anotherErrorsForUnitSymbol
+      );
+
+      const anotherErrorsForSiNotation =
+        errorsByProperty.get("siNotation");
+      setErrorsForSiNotation(
+        anotherErrorsForSiNotation === undefined
+          ? null
+          : anotherErrorsForSiNotation
+      );
+
+      const anotherErrorsForSiName =
+        errorsByProperty.get("siName");
+      setErrorsForSiName(
+        anotherErrorsForSiName === undefined
+          ? null
+          : anotherErrorsForSiName
+      );
+
+      const anotherErrorsForDinNotation =
+        errorsByProperty.get("dinNotation");
+      setErrorsForDinNotation(
+        anotherErrorsForDinNotation === undefined
+          ? null
+          : anotherErrorsForDinNotation
+      );
+
+      const anotherErrorsForEceName =
+        errorsByProperty.get("eceName");
+      setErrorsForEceName(
+        anotherErrorsForEceName === undefined
+          ? null
+          : anotherErrorsForEceName
+      );
+
+      const anotherErrorsForEceCode =
+        errorsByProperty.get("eceCode");
+      setErrorsForEceCode(
+        anotherErrorsForEceCode === undefined
+          ? null
+          : anotherErrorsForEceCode
+      );
+
+      const anotherErrorsForNistName =
+        errorsByProperty.get("nistName");
+      setErrorsForNistName(
+        anotherErrorsForNistName === undefined
+          ? null
+          : anotherErrorsForNistName
+      );
+
+      const anotherErrorsForSourceOfDefinition =
+        errorsByProperty.get("sourceOfDefinition");
+      setErrorsForSourceOfDefinition(
+        anotherErrorsForSourceOfDefinition === undefined
+          ? null
+          : anotherErrorsForSourceOfDefinition
+      );
+
+      const anotherErrorsForConversionFactor =
+        errorsByProperty.get("conversionFactor");
+      setErrorsForConversionFactor(
+        anotherErrorsForConversionFactor === undefined
+          ? null
+          : anotherErrorsForConversionFactor
+      );
+
+      const anotherErrorsForRegistrationAuthorityId =
+        errorsByProperty.get("registrationAuthorityId");
+      setErrorsForRegistrationAuthorityId(
+        anotherErrorsForRegistrationAuthorityId === undefined
+          ? null
+          : anotherErrorsForRegistrationAuthorityId
+      );
+
+      const anotherErrorsForSupplier =
+        errorsByProperty.get("supplier");
+      setErrorsForSupplier(
+        anotherErrorsForSupplier === undefined
+          ? null
+          : anotherErrorsForSupplier
+      );
+    },
+    [
+      snapErrorSetVersioning,
+      props.instance
+    ]
+  );
   return (
     <>
+    <widgets.LocalErrors errors={instanceErrors} />
       <fields.TextFieldRequired
         label="Unit name"
         helpUrl={
@@ -35,6 +196,7 @@ export function DataSpecificationPhysicalUnitFields(
             props.instance.unitName = value;
           }
         }
+        errors={errorsForUnitName}
       />
 
       <fields.TextFieldRequired
@@ -48,6 +210,7 @@ export function DataSpecificationPhysicalUnitFields(
             props.instance.unitSymbol = value;
           }
         }
+        errors={errorsForUnitSymbol}
       />
 
       <fields.ListFieldRequired<aas.types.LangString>
@@ -84,6 +247,7 @@ export function DataSpecificationPhysicalUnitFields(
             props.instance.siNotation = value;
           }
         }
+        errors={errorsForSiNotation}
       />
 
       <fields.TextFieldOptional
@@ -97,6 +261,7 @@ export function DataSpecificationPhysicalUnitFields(
             props.instance.siName = value;
           }
         }
+        errors={errorsForSiName}
       />
 
       <fields.TextFieldOptional
@@ -110,6 +275,7 @@ export function DataSpecificationPhysicalUnitFields(
             props.instance.dinNotation = value;
           }
         }
+        errors={errorsForDinNotation}
       />
 
       <fields.TextFieldOptional
@@ -123,6 +289,7 @@ export function DataSpecificationPhysicalUnitFields(
             props.instance.eceName = value;
           }
         }
+        errors={errorsForEceName}
       />
 
       <fields.TextFieldOptional
@@ -136,6 +303,7 @@ export function DataSpecificationPhysicalUnitFields(
             props.instance.eceCode = value;
           }
         }
+        errors={errorsForEceCode}
       />
 
       <fields.TextFieldOptional
@@ -149,6 +317,7 @@ export function DataSpecificationPhysicalUnitFields(
             props.instance.nistName = value;
           }
         }
+        errors={errorsForNistName}
       />
 
       <fields.TextFieldOptional
@@ -162,6 +331,7 @@ export function DataSpecificationPhysicalUnitFields(
             props.instance.sourceOfDefinition = value;
           }
         }
+        errors={errorsForSourceOfDefinition}
       />
 
       <fields.TextFieldOptional
@@ -175,6 +345,7 @@ export function DataSpecificationPhysicalUnitFields(
             props.instance.conversionFactor = value;
           }
         }
+        errors={errorsForConversionFactor}
       />
 
       <fields.TextFieldOptional
@@ -188,6 +359,7 @@ export function DataSpecificationPhysicalUnitFields(
             props.instance.registrationAuthorityId = value;
           }
         }
+        errors={errorsForRegistrationAuthorityId}
       />
 
       <fields.TextFieldOptional
@@ -201,6 +373,7 @@ export function DataSpecificationPhysicalUnitFields(
             props.instance.supplier = value;
           }
         }
+        errors={errorsForSupplier}
       />
     </>
   )

--- a/src/components/instances/EmbeddedDataSpecificationFields.generated.tsx
+++ b/src/components/instances/EmbeddedDataSpecificationFields.generated.tsx
@@ -11,10 +11,15 @@
 
 import * as aas from "@aas-core-works/aas-core3.0rc02-typescript";
 import * as React from "react";
+import * as valtio from "valtio";
 
-import * as fields from '../fields';
-import * as help from './help.generated';
-import * as newinstancing from '../../newinstancing.generated';
+import * as enhancing from "../../enhancing.generated";
+import * as fields from "../fields";
+import * as help from "./help.generated";
+import * as model from "../../model";
+import * as newinstancing from "../../newinstancing.generated";
+import * as verification from "../../verification";
+import * as widgets from "../widgets";
 
 export function EmbeddedDataSpecificationFields(
   props: {
@@ -22,8 +27,32 @@ export function EmbeddedDataSpecificationFields(
     instance: aas.types.EmbeddedDataSpecification,
   }
 ) {
+  const [instanceErrors, setInstanceErrors] = React.useState<
+    Array<enhancing.TimestampedError> | null>(null);
+
+  const snapErrorSetVersioning = valtio.useSnapshot(
+    model.getErrorSet(props.instance).versioning
+  );
+
+  React.useEffect(
+    () => {
+      const [
+        anotherInstanceErrors,
+        _
+      ] = verification.categorizeInstanceErrors(
+        model.getErrorSet(props.instance)
+      );
+
+      setInstanceErrors(anotherInstanceErrors);
+    },
+    [
+      snapErrorSetVersioning,
+      props.instance
+    ]
+  );
   return (
     <>
+    <widgets.LocalErrors errors={instanceErrors} />
       <fields.EmbeddedInstanceRequired<aas.types.Reference>
         label="Data specification"
         helpUrl={

--- a/src/components/instances/EntityFields.generated.tsx
+++ b/src/components/instances/EntityFields.generated.tsx
@@ -11,10 +11,15 @@
 
 import * as aas from "@aas-core-works/aas-core3.0rc02-typescript";
 import * as React from "react";
+import * as valtio from "valtio";
 
-import * as fields from '../fields';
-import * as help from './help.generated';
-import * as newinstancing from '../../newinstancing.generated';
+import * as enhancing from "../../enhancing.generated";
+import * as fields from "../fields";
+import * as help from "./help.generated";
+import * as model from "../../model";
+import * as newinstancing from "../../newinstancing.generated";
+import * as verification from "../../verification";
+import * as widgets from "../widgets";
 
 export function EntityFields(
   props: {
@@ -22,8 +27,87 @@ export function EntityFields(
     instance: aas.types.Entity,
   }
 ) {
+  const [instanceErrors, setInstanceErrors] = React.useState<
+    Array<enhancing.TimestampedError> | null>(null);
+
+  const [errorsForCategory, setErrorsForCategory] = React.useState<
+    Array<enhancing.TimestampedError> | null>(null);
+
+  const [errorsForIdShort, setErrorsForIdShort] = React.useState<
+    Array<enhancing.TimestampedError> | null>(null);
+
+  const [errorsForChecksum, setErrorsForChecksum] = React.useState<
+    Array<enhancing.TimestampedError> | null>(null);
+
+  const [errorsForKind, setErrorsForKind] = React.useState<
+    Array<enhancing.TimestampedError> | null>(null);
+
+  const [errorsForEntityType, setErrorsForEntityType] = React.useState<
+    Array<enhancing.TimestampedError> | null>(null);
+
+  const snapErrorSetVersioning = valtio.useSnapshot(
+    model.getErrorSet(props.instance).versioning
+  );
+
+  React.useEffect(
+    () => {
+      const [
+        anotherInstanceErrors,
+        errorsByProperty
+      ] = verification.categorizeInstanceErrors(
+        model.getErrorSet(props.instance)
+      );
+
+      setInstanceErrors(anotherInstanceErrors);
+
+      const anotherErrorsForCategory =
+        errorsByProperty.get("category");
+      setErrorsForCategory(
+        anotherErrorsForCategory === undefined
+          ? null
+          : anotherErrorsForCategory
+      );
+
+      const anotherErrorsForIdShort =
+        errorsByProperty.get("idShort");
+      setErrorsForIdShort(
+        anotherErrorsForIdShort === undefined
+          ? null
+          : anotherErrorsForIdShort
+      );
+
+      const anotherErrorsForChecksum =
+        errorsByProperty.get("checksum");
+      setErrorsForChecksum(
+        anotherErrorsForChecksum === undefined
+          ? null
+          : anotherErrorsForChecksum
+      );
+
+      const anotherErrorsForKind =
+        errorsByProperty.get("kind");
+      setErrorsForKind(
+        anotherErrorsForKind === undefined
+          ? null
+          : anotherErrorsForKind
+      );
+
+      const anotherErrorsForEntityType =
+        errorsByProperty.get("entityType");
+      setErrorsForEntityType(
+        anotherErrorsForEntityType === undefined
+          ? null
+          : anotherErrorsForEntityType
+      );
+    },
+    [
+      snapErrorSetVersioning,
+      props.instance
+    ]
+  );
   return (
     <>
+    <widgets.LocalErrors errors={instanceErrors} />
       <fields.ListFieldOptional<aas.types.Extension>
         label="Extensions"
         helpUrl={
@@ -58,6 +142,7 @@ export function EntityFields(
             props.instance.category = value;
           }
         }
+        errors={errorsForCategory}
       />
 
       <fields.TextFieldOptional
@@ -71,6 +156,7 @@ export function EntityFields(
             props.instance.idShort = value;
           }
         }
+        errors={errorsForIdShort}
       />
 
       <fields.ListFieldOptional<aas.types.LangString>
@@ -130,6 +216,7 @@ export function EntityFields(
             props.instance.checksum = value;
           }
         }
+        errors={errorsForChecksum}
       />
 
       <fields.EnumerationFieldOptional
@@ -145,6 +232,7 @@ export function EntityFields(
             props.instance.kind = value;
           }
         }
+        errors={errorsForKind}
       />
 
       <fields.EmbeddedInstanceOptional<aas.types.Reference>
@@ -275,6 +363,7 @@ export function EntityFields(
             props.instance.entityType = value;
           }
         }
+        errors={errorsForEntityType}
       />
 
       <fields.EmbeddedInstanceOptional<aas.types.Reference>

--- a/src/components/instances/EnvironmentFields.generated.tsx
+++ b/src/components/instances/EnvironmentFields.generated.tsx
@@ -11,10 +11,15 @@
 
 import * as aas from "@aas-core-works/aas-core3.0rc02-typescript";
 import * as React from "react";
+import * as valtio from "valtio";
 
-import * as fields from '../fields';
-import * as help from './help.generated';
-import * as newinstancing from '../../newinstancing.generated';
+import * as enhancing from "../../enhancing.generated";
+import * as fields from "../fields";
+import * as help from "./help.generated";
+import * as model from "../../model";
+import * as newinstancing from "../../newinstancing.generated";
+import * as verification from "../../verification";
+import * as widgets from "../widgets";
 
 export function EnvironmentFields(
   props: {
@@ -22,8 +27,32 @@ export function EnvironmentFields(
     instance: aas.types.Environment,
   }
 ) {
+  const [instanceErrors, setInstanceErrors] = React.useState<
+    Array<enhancing.TimestampedError> | null>(null);
+
+  const snapErrorSetVersioning = valtio.useSnapshot(
+    model.getErrorSet(props.instance).versioning
+  );
+
+  React.useEffect(
+    () => {
+      const [
+        anotherInstanceErrors,
+        _
+      ] = verification.categorizeInstanceErrors(
+        model.getErrorSet(props.instance)
+      );
+
+      setInstanceErrors(anotherInstanceErrors);
+    },
+    [
+      snapErrorSetVersioning,
+      props.instance
+    ]
+  );
   return (
     <>
+    <widgets.LocalErrors errors={instanceErrors} />
       <fields.ListFieldOptional<aas.types.AssetAdministrationShell>
         label="Asset administration shells"
         helpUrl={

--- a/src/components/instances/EventPayloadFields.generated.tsx
+++ b/src/components/instances/EventPayloadFields.generated.tsx
@@ -11,10 +11,15 @@
 
 import * as aas from "@aas-core-works/aas-core3.0rc02-typescript";
 import * as React from "react";
+import * as valtio from "valtio";
 
-import * as fields from '../fields';
-import * as help from './help.generated';
-import * as newinstancing from '../../newinstancing.generated';
+import * as enhancing from "../../enhancing.generated";
+import * as fields from "../fields";
+import * as help from "./help.generated";
+import * as model from "../../model";
+import * as newinstancing from "../../newinstancing.generated";
+import * as verification from "../../verification";
+import * as widgets from "../widgets";
 
 export function EventPayloadFields(
   props: {
@@ -22,8 +27,65 @@ export function EventPayloadFields(
     instance: aas.types.EventPayload,
   }
 ) {
+  const [instanceErrors, setInstanceErrors] = React.useState<
+    Array<enhancing.TimestampedError> | null>(null);
+
+  const [errorsForTopic, setErrorsForTopic] = React.useState<
+    Array<enhancing.TimestampedError> | null>(null);
+
+  const [errorsForTimeStamp, setErrorsForTimeStamp] = React.useState<
+    Array<enhancing.TimestampedError> | null>(null);
+
+  const [errorsForPayload, setErrorsForPayload] = React.useState<
+    Array<enhancing.TimestampedError> | null>(null);
+
+  const snapErrorSetVersioning = valtio.useSnapshot(
+    model.getErrorSet(props.instance).versioning
+  );
+
+  React.useEffect(
+    () => {
+      const [
+        anotherInstanceErrors,
+        errorsByProperty
+      ] = verification.categorizeInstanceErrors(
+        model.getErrorSet(props.instance)
+      );
+
+      setInstanceErrors(anotherInstanceErrors);
+
+      const anotherErrorsForTopic =
+        errorsByProperty.get("topic");
+      setErrorsForTopic(
+        anotherErrorsForTopic === undefined
+          ? null
+          : anotherErrorsForTopic
+      );
+
+      const anotherErrorsForTimeStamp =
+        errorsByProperty.get("timeStamp");
+      setErrorsForTimeStamp(
+        anotherErrorsForTimeStamp === undefined
+          ? null
+          : anotherErrorsForTimeStamp
+      );
+
+      const anotherErrorsForPayload =
+        errorsByProperty.get("payload");
+      setErrorsForPayload(
+        anotherErrorsForPayload === undefined
+          ? null
+          : anotherErrorsForPayload
+      );
+    },
+    [
+      snapErrorSetVersioning,
+      props.instance
+    ]
+  );
   return (
     <>
+    <widgets.LocalErrors errors={instanceErrors} />
       <fields.EmbeddedInstanceRequired<aas.types.Reference>
         label="Source"
         helpUrl={
@@ -127,6 +189,7 @@ export function EventPayloadFields(
             props.instance.topic = value;
           }
         }
+        errors={errorsForTopic}
       />
 
       <fields.EmbeddedInstanceOptional<aas.types.Reference>
@@ -163,6 +226,7 @@ export function EventPayloadFields(
             props.instance.timeStamp = value;
           }
         }
+        errors={errorsForTimeStamp}
       />
 
       <fields.TextFieldOptional
@@ -176,6 +240,7 @@ export function EventPayloadFields(
             props.instance.payload = value;
           }
         }
+        errors={errorsForPayload}
       />
     </>
   )

--- a/src/components/instances/ExtensionFields.generated.tsx
+++ b/src/components/instances/ExtensionFields.generated.tsx
@@ -11,10 +11,15 @@
 
 import * as aas from "@aas-core-works/aas-core3.0rc02-typescript";
 import * as React from "react";
+import * as valtio from "valtio";
 
-import * as fields from '../fields';
-import * as help from './help.generated';
-import * as newinstancing from '../../newinstancing.generated';
+import * as enhancing from "../../enhancing.generated";
+import * as fields from "../fields";
+import * as help from "./help.generated";
+import * as model from "../../model";
+import * as newinstancing from "../../newinstancing.generated";
+import * as verification from "../../verification";
+import * as widgets from "../widgets";
 
 export function ExtensionFields(
   props: {
@@ -22,8 +27,65 @@ export function ExtensionFields(
     instance: aas.types.Extension,
   }
 ) {
+  const [instanceErrors, setInstanceErrors] = React.useState<
+    Array<enhancing.TimestampedError> | null>(null);
+
+  const [errorsForName, setErrorsForName] = React.useState<
+    Array<enhancing.TimestampedError> | null>(null);
+
+  const [errorsForValueType, setErrorsForValueType] = React.useState<
+    Array<enhancing.TimestampedError> | null>(null);
+
+  const [errorsForValue, setErrorsForValue] = React.useState<
+    Array<enhancing.TimestampedError> | null>(null);
+
+  const snapErrorSetVersioning = valtio.useSnapshot(
+    model.getErrorSet(props.instance).versioning
+  );
+
+  React.useEffect(
+    () => {
+      const [
+        anotherInstanceErrors,
+        errorsByProperty
+      ] = verification.categorizeInstanceErrors(
+        model.getErrorSet(props.instance)
+      );
+
+      setInstanceErrors(anotherInstanceErrors);
+
+      const anotherErrorsForName =
+        errorsByProperty.get("name");
+      setErrorsForName(
+        anotherErrorsForName === undefined
+          ? null
+          : anotherErrorsForName
+      );
+
+      const anotherErrorsForValueType =
+        errorsByProperty.get("valueType");
+      setErrorsForValueType(
+        anotherErrorsForValueType === undefined
+          ? null
+          : anotherErrorsForValueType
+      );
+
+      const anotherErrorsForValue =
+        errorsByProperty.get("value");
+      setErrorsForValue(
+        anotherErrorsForValue === undefined
+          ? null
+          : anotherErrorsForValue
+      );
+    },
+    [
+      snapErrorSetVersioning,
+      props.instance
+    ]
+  );
   return (
     <>
+    <widgets.LocalErrors errors={instanceErrors} />
       <fields.EmbeddedInstanceOptional<aas.types.Reference>
         label="Semantic id"
         helpUrl={
@@ -81,6 +143,7 @@ export function ExtensionFields(
             props.instance.name = value;
           }
         }
+        errors={errorsForName}
       />
 
       <fields.EnumerationFieldOptional
@@ -96,6 +159,7 @@ export function ExtensionFields(
             props.instance.valueType = value;
           }
         }
+        errors={errorsForValueType}
       />
 
       <fields.TextFieldOptional
@@ -109,6 +173,7 @@ export function ExtensionFields(
             props.instance.value = value;
           }
         }
+        errors={errorsForValue}
       />
 
       <fields.EmbeddedInstanceOptional<aas.types.Reference>

--- a/src/components/instances/FileFields.generated.tsx
+++ b/src/components/instances/FileFields.generated.tsx
@@ -11,10 +11,15 @@
 
 import * as aas from "@aas-core-works/aas-core3.0rc02-typescript";
 import * as React from "react";
+import * as valtio from "valtio";
 
-import * as fields from '../fields';
-import * as help from './help.generated';
-import * as newinstancing from '../../newinstancing.generated';
+import * as enhancing from "../../enhancing.generated";
+import * as fields from "../fields";
+import * as help from "./help.generated";
+import * as model from "../../model";
+import * as newinstancing from "../../newinstancing.generated";
+import * as verification from "../../verification";
+import * as widgets from "../widgets";
 
 export function FileFields(
   props: {
@@ -22,8 +27,98 @@ export function FileFields(
     instance: aas.types.File,
   }
 ) {
+  const [instanceErrors, setInstanceErrors] = React.useState<
+    Array<enhancing.TimestampedError> | null>(null);
+
+  const [errorsForCategory, setErrorsForCategory] = React.useState<
+    Array<enhancing.TimestampedError> | null>(null);
+
+  const [errorsForIdShort, setErrorsForIdShort] = React.useState<
+    Array<enhancing.TimestampedError> | null>(null);
+
+  const [errorsForChecksum, setErrorsForChecksum] = React.useState<
+    Array<enhancing.TimestampedError> | null>(null);
+
+  const [errorsForKind, setErrorsForKind] = React.useState<
+    Array<enhancing.TimestampedError> | null>(null);
+
+  const [errorsForValue, setErrorsForValue] = React.useState<
+    Array<enhancing.TimestampedError> | null>(null);
+
+  const [errorsForContentType, setErrorsForContentType] = React.useState<
+    Array<enhancing.TimestampedError> | null>(null);
+
+  const snapErrorSetVersioning = valtio.useSnapshot(
+    model.getErrorSet(props.instance).versioning
+  );
+
+  React.useEffect(
+    () => {
+      const [
+        anotherInstanceErrors,
+        errorsByProperty
+      ] = verification.categorizeInstanceErrors(
+        model.getErrorSet(props.instance)
+      );
+
+      setInstanceErrors(anotherInstanceErrors);
+
+      const anotherErrorsForCategory =
+        errorsByProperty.get("category");
+      setErrorsForCategory(
+        anotherErrorsForCategory === undefined
+          ? null
+          : anotherErrorsForCategory
+      );
+
+      const anotherErrorsForIdShort =
+        errorsByProperty.get("idShort");
+      setErrorsForIdShort(
+        anotherErrorsForIdShort === undefined
+          ? null
+          : anotherErrorsForIdShort
+      );
+
+      const anotherErrorsForChecksum =
+        errorsByProperty.get("checksum");
+      setErrorsForChecksum(
+        anotherErrorsForChecksum === undefined
+          ? null
+          : anotherErrorsForChecksum
+      );
+
+      const anotherErrorsForKind =
+        errorsByProperty.get("kind");
+      setErrorsForKind(
+        anotherErrorsForKind === undefined
+          ? null
+          : anotherErrorsForKind
+      );
+
+      const anotherErrorsForValue =
+        errorsByProperty.get("value");
+      setErrorsForValue(
+        anotherErrorsForValue === undefined
+          ? null
+          : anotherErrorsForValue
+      );
+
+      const anotherErrorsForContentType =
+        errorsByProperty.get("contentType");
+      setErrorsForContentType(
+        anotherErrorsForContentType === undefined
+          ? null
+          : anotherErrorsForContentType
+      );
+    },
+    [
+      snapErrorSetVersioning,
+      props.instance
+    ]
+  );
   return (
     <>
+    <widgets.LocalErrors errors={instanceErrors} />
       <fields.ListFieldOptional<aas.types.Extension>
         label="Extensions"
         helpUrl={
@@ -58,6 +153,7 @@ export function FileFields(
             props.instance.category = value;
           }
         }
+        errors={errorsForCategory}
       />
 
       <fields.TextFieldOptional
@@ -71,6 +167,7 @@ export function FileFields(
             props.instance.idShort = value;
           }
         }
+        errors={errorsForIdShort}
       />
 
       <fields.ListFieldOptional<aas.types.LangString>
@@ -130,6 +227,7 @@ export function FileFields(
             props.instance.checksum = value;
           }
         }
+        errors={errorsForChecksum}
       />
 
       <fields.EnumerationFieldOptional
@@ -145,6 +243,7 @@ export function FileFields(
             props.instance.kind = value;
           }
         }
+        errors={errorsForKind}
       />
 
       <fields.EmbeddedInstanceOptional<aas.types.Reference>
@@ -250,6 +349,7 @@ export function FileFields(
             props.instance.value = value;
           }
         }
+        errors={errorsForValue}
       />
 
       <fields.TextFieldRequired
@@ -263,6 +363,7 @@ export function FileFields(
             props.instance.contentType = value;
           }
         }
+        errors={errorsForContentType}
       />
     </>
   )

--- a/src/components/instances/KeyFields.generated.tsx
+++ b/src/components/instances/KeyFields.generated.tsx
@@ -11,10 +11,15 @@
 
 import * as aas from "@aas-core-works/aas-core3.0rc02-typescript";
 import * as React from "react";
+import * as valtio from "valtio";
 
-import * as fields from '../fields';
-import * as help from './help.generated';
-import * as newinstancing from '../../newinstancing.generated';
+import * as enhancing from "../../enhancing.generated";
+import * as fields from "../fields";
+import * as help from "./help.generated";
+import * as model from "../../model";
+import * as newinstancing from "../../newinstancing.generated";
+import * as verification from "../../verification";
+import * as widgets from "../widgets";
 
 export function KeyFields(
   props: {
@@ -22,8 +27,54 @@ export function KeyFields(
     instance: aas.types.Key,
   }
 ) {
+  const [instanceErrors, setInstanceErrors] = React.useState<
+    Array<enhancing.TimestampedError> | null>(null);
+
+  const [errorsForType, setErrorsForType] = React.useState<
+    Array<enhancing.TimestampedError> | null>(null);
+
+  const [errorsForValue, setErrorsForValue] = React.useState<
+    Array<enhancing.TimestampedError> | null>(null);
+
+  const snapErrorSetVersioning = valtio.useSnapshot(
+    model.getErrorSet(props.instance).versioning
+  );
+
+  React.useEffect(
+    () => {
+      const [
+        anotherInstanceErrors,
+        errorsByProperty
+      ] = verification.categorizeInstanceErrors(
+        model.getErrorSet(props.instance)
+      );
+
+      setInstanceErrors(anotherInstanceErrors);
+
+      const anotherErrorsForType =
+        errorsByProperty.get("type");
+      setErrorsForType(
+        anotherErrorsForType === undefined
+          ? null
+          : anotherErrorsForType
+      );
+
+      const anotherErrorsForValue =
+        errorsByProperty.get("value");
+      setErrorsForValue(
+        anotherErrorsForValue === undefined
+          ? null
+          : anotherErrorsForValue
+      );
+    },
+    [
+      snapErrorSetVersioning,
+      props.instance
+    ]
+  );
   return (
     <>
+    <widgets.LocalErrors errors={instanceErrors} />
       <fields.EnumerationFieldRequired
         label="Type"
         helpUrl={
@@ -37,6 +88,7 @@ export function KeyFields(
             props.instance.type = value;
           }
         }
+        errors={errorsForType}
       />
 
       <fields.TextFieldRequired
@@ -50,6 +102,7 @@ export function KeyFields(
             props.instance.value = value;
           }
         }
+        errors={errorsForValue}
       />
     </>
   )

--- a/src/components/instances/LangStringFields.generated.tsx
+++ b/src/components/instances/LangStringFields.generated.tsx
@@ -11,10 +11,15 @@
 
 import * as aas from "@aas-core-works/aas-core3.0rc02-typescript";
 import * as React from "react";
+import * as valtio from "valtio";
 
-import * as fields from '../fields';
-import * as help from './help.generated';
-import * as newinstancing from '../../newinstancing.generated';
+import * as enhancing from "../../enhancing.generated";
+import * as fields from "../fields";
+import * as help from "./help.generated";
+import * as model from "../../model";
+import * as newinstancing from "../../newinstancing.generated";
+import * as verification from "../../verification";
+import * as widgets from "../widgets";
 
 export function LangStringFields(
   props: {
@@ -22,8 +27,54 @@ export function LangStringFields(
     instance: aas.types.LangString,
   }
 ) {
+  const [instanceErrors, setInstanceErrors] = React.useState<
+    Array<enhancing.TimestampedError> | null>(null);
+
+  const [errorsForLanguage, setErrorsForLanguage] = React.useState<
+    Array<enhancing.TimestampedError> | null>(null);
+
+  const [errorsForText, setErrorsForText] = React.useState<
+    Array<enhancing.TimestampedError> | null>(null);
+
+  const snapErrorSetVersioning = valtio.useSnapshot(
+    model.getErrorSet(props.instance).versioning
+  );
+
+  React.useEffect(
+    () => {
+      const [
+        anotherInstanceErrors,
+        errorsByProperty
+      ] = verification.categorizeInstanceErrors(
+        model.getErrorSet(props.instance)
+      );
+
+      setInstanceErrors(anotherInstanceErrors);
+
+      const anotherErrorsForLanguage =
+        errorsByProperty.get("language");
+      setErrorsForLanguage(
+        anotherErrorsForLanguage === undefined
+          ? null
+          : anotherErrorsForLanguage
+      );
+
+      const anotherErrorsForText =
+        errorsByProperty.get("text");
+      setErrorsForText(
+        anotherErrorsForText === undefined
+          ? null
+          : anotherErrorsForText
+      );
+    },
+    [
+      snapErrorSetVersioning,
+      props.instance
+    ]
+  );
   return (
     <>
+    <widgets.LocalErrors errors={instanceErrors} />
       <fields.TextFieldRequired
         label="Language"
         helpUrl={
@@ -35,6 +86,7 @@ export function LangStringFields(
             props.instance.language = value;
           }
         }
+        errors={errorsForLanguage}
       />
 
       <fields.TextFieldRequired
@@ -48,6 +100,7 @@ export function LangStringFields(
             props.instance.text = value;
           }
         }
+        errors={errorsForText}
       />
     </>
   )

--- a/src/components/instances/MultiLanguagePropertyFields.generated.tsx
+++ b/src/components/instances/MultiLanguagePropertyFields.generated.tsx
@@ -11,10 +11,15 @@
 
 import * as aas from "@aas-core-works/aas-core3.0rc02-typescript";
 import * as React from "react";
+import * as valtio from "valtio";
 
-import * as fields from '../fields';
-import * as help from './help.generated';
-import * as newinstancing from '../../newinstancing.generated';
+import * as enhancing from "../../enhancing.generated";
+import * as fields from "../fields";
+import * as help from "./help.generated";
+import * as model from "../../model";
+import * as newinstancing from "../../newinstancing.generated";
+import * as verification from "../../verification";
+import * as widgets from "../widgets";
 
 export function MultiLanguagePropertyFields(
   props: {
@@ -22,8 +27,76 @@ export function MultiLanguagePropertyFields(
     instance: aas.types.MultiLanguageProperty,
   }
 ) {
+  const [instanceErrors, setInstanceErrors] = React.useState<
+    Array<enhancing.TimestampedError> | null>(null);
+
+  const [errorsForCategory, setErrorsForCategory] = React.useState<
+    Array<enhancing.TimestampedError> | null>(null);
+
+  const [errorsForIdShort, setErrorsForIdShort] = React.useState<
+    Array<enhancing.TimestampedError> | null>(null);
+
+  const [errorsForChecksum, setErrorsForChecksum] = React.useState<
+    Array<enhancing.TimestampedError> | null>(null);
+
+  const [errorsForKind, setErrorsForKind] = React.useState<
+    Array<enhancing.TimestampedError> | null>(null);
+
+  const snapErrorSetVersioning = valtio.useSnapshot(
+    model.getErrorSet(props.instance).versioning
+  );
+
+  React.useEffect(
+    () => {
+      const [
+        anotherInstanceErrors,
+        errorsByProperty
+      ] = verification.categorizeInstanceErrors(
+        model.getErrorSet(props.instance)
+      );
+
+      setInstanceErrors(anotherInstanceErrors);
+
+      const anotherErrorsForCategory =
+        errorsByProperty.get("category");
+      setErrorsForCategory(
+        anotherErrorsForCategory === undefined
+          ? null
+          : anotherErrorsForCategory
+      );
+
+      const anotherErrorsForIdShort =
+        errorsByProperty.get("idShort");
+      setErrorsForIdShort(
+        anotherErrorsForIdShort === undefined
+          ? null
+          : anotherErrorsForIdShort
+      );
+
+      const anotherErrorsForChecksum =
+        errorsByProperty.get("checksum");
+      setErrorsForChecksum(
+        anotherErrorsForChecksum === undefined
+          ? null
+          : anotherErrorsForChecksum
+      );
+
+      const anotherErrorsForKind =
+        errorsByProperty.get("kind");
+      setErrorsForKind(
+        anotherErrorsForKind === undefined
+          ? null
+          : anotherErrorsForKind
+      );
+    },
+    [
+      snapErrorSetVersioning,
+      props.instance
+    ]
+  );
   return (
     <>
+    <widgets.LocalErrors errors={instanceErrors} />
       <fields.ListFieldOptional<aas.types.Extension>
         label="Extensions"
         helpUrl={
@@ -58,6 +131,7 @@ export function MultiLanguagePropertyFields(
             props.instance.category = value;
           }
         }
+        errors={errorsForCategory}
       />
 
       <fields.TextFieldOptional
@@ -71,6 +145,7 @@ export function MultiLanguagePropertyFields(
             props.instance.idShort = value;
           }
         }
+        errors={errorsForIdShort}
       />
 
       <fields.ListFieldOptional<aas.types.LangString>
@@ -130,6 +205,7 @@ export function MultiLanguagePropertyFields(
             props.instance.checksum = value;
           }
         }
+        errors={errorsForChecksum}
       />
 
       <fields.EnumerationFieldOptional
@@ -145,6 +221,7 @@ export function MultiLanguagePropertyFields(
             props.instance.kind = value;
           }
         }
+        errors={errorsForKind}
       />
 
       <fields.EmbeddedInstanceOptional<aas.types.Reference>

--- a/src/components/instances/OperationFields.generated.tsx
+++ b/src/components/instances/OperationFields.generated.tsx
@@ -11,10 +11,15 @@
 
 import * as aas from "@aas-core-works/aas-core3.0rc02-typescript";
 import * as React from "react";
+import * as valtio from "valtio";
 
-import * as fields from '../fields';
-import * as help from './help.generated';
-import * as newinstancing from '../../newinstancing.generated';
+import * as enhancing from "../../enhancing.generated";
+import * as fields from "../fields";
+import * as help from "./help.generated";
+import * as model from "../../model";
+import * as newinstancing from "../../newinstancing.generated";
+import * as verification from "../../verification";
+import * as widgets from "../widgets";
 
 export function OperationFields(
   props: {
@@ -22,8 +27,76 @@ export function OperationFields(
     instance: aas.types.Operation,
   }
 ) {
+  const [instanceErrors, setInstanceErrors] = React.useState<
+    Array<enhancing.TimestampedError> | null>(null);
+
+  const [errorsForCategory, setErrorsForCategory] = React.useState<
+    Array<enhancing.TimestampedError> | null>(null);
+
+  const [errorsForIdShort, setErrorsForIdShort] = React.useState<
+    Array<enhancing.TimestampedError> | null>(null);
+
+  const [errorsForChecksum, setErrorsForChecksum] = React.useState<
+    Array<enhancing.TimestampedError> | null>(null);
+
+  const [errorsForKind, setErrorsForKind] = React.useState<
+    Array<enhancing.TimestampedError> | null>(null);
+
+  const snapErrorSetVersioning = valtio.useSnapshot(
+    model.getErrorSet(props.instance).versioning
+  );
+
+  React.useEffect(
+    () => {
+      const [
+        anotherInstanceErrors,
+        errorsByProperty
+      ] = verification.categorizeInstanceErrors(
+        model.getErrorSet(props.instance)
+      );
+
+      setInstanceErrors(anotherInstanceErrors);
+
+      const anotherErrorsForCategory =
+        errorsByProperty.get("category");
+      setErrorsForCategory(
+        anotherErrorsForCategory === undefined
+          ? null
+          : anotherErrorsForCategory
+      );
+
+      const anotherErrorsForIdShort =
+        errorsByProperty.get("idShort");
+      setErrorsForIdShort(
+        anotherErrorsForIdShort === undefined
+          ? null
+          : anotherErrorsForIdShort
+      );
+
+      const anotherErrorsForChecksum =
+        errorsByProperty.get("checksum");
+      setErrorsForChecksum(
+        anotherErrorsForChecksum === undefined
+          ? null
+          : anotherErrorsForChecksum
+      );
+
+      const anotherErrorsForKind =
+        errorsByProperty.get("kind");
+      setErrorsForKind(
+        anotherErrorsForKind === undefined
+          ? null
+          : anotherErrorsForKind
+      );
+    },
+    [
+      snapErrorSetVersioning,
+      props.instance
+    ]
+  );
   return (
     <>
+    <widgets.LocalErrors errors={instanceErrors} />
       <fields.ListFieldOptional<aas.types.Extension>
         label="Extensions"
         helpUrl={
@@ -58,6 +131,7 @@ export function OperationFields(
             props.instance.category = value;
           }
         }
+        errors={errorsForCategory}
       />
 
       <fields.TextFieldOptional
@@ -71,6 +145,7 @@ export function OperationFields(
             props.instance.idShort = value;
           }
         }
+        errors={errorsForIdShort}
       />
 
       <fields.ListFieldOptional<aas.types.LangString>
@@ -130,6 +205,7 @@ export function OperationFields(
             props.instance.checksum = value;
           }
         }
+        errors={errorsForChecksum}
       />
 
       <fields.EnumerationFieldOptional
@@ -145,6 +221,7 @@ export function OperationFields(
             props.instance.kind = value;
           }
         }
+        errors={errorsForKind}
       />
 
       <fields.EmbeddedInstanceOptional<aas.types.Reference>

--- a/src/components/instances/OperationVariableFields.generated.tsx
+++ b/src/components/instances/OperationVariableFields.generated.tsx
@@ -11,10 +11,15 @@
 
 import * as aas from "@aas-core-works/aas-core3.0rc02-typescript";
 import * as React from "react";
+import * as valtio from "valtio";
 
-import * as fields from '../fields';
-import * as help from './help.generated';
-import * as newinstancing from '../../newinstancing.generated';
+import * as enhancing from "../../enhancing.generated";
+import * as fields from "../fields";
+import * as help from "./help.generated";
+import * as model from "../../model";
+import * as newinstancing from "../../newinstancing.generated";
+import * as verification from "../../verification";
+import * as widgets from "../widgets";
 
 export function OperationVariableFields(
   props: {
@@ -22,8 +27,32 @@ export function OperationVariableFields(
     instance: aas.types.OperationVariable,
   }
 ) {
+  const [instanceErrors, setInstanceErrors] = React.useState<
+    Array<enhancing.TimestampedError> | null>(null);
+
+  const snapErrorSetVersioning = valtio.useSnapshot(
+    model.getErrorSet(props.instance).versioning
+  );
+
+  React.useEffect(
+    () => {
+      const [
+        anotherInstanceErrors,
+        _
+      ] = verification.categorizeInstanceErrors(
+        model.getErrorSet(props.instance)
+      );
+
+      setInstanceErrors(anotherInstanceErrors);
+    },
+    [
+      snapErrorSetVersioning,
+      props.instance
+    ]
+  );
   return (
     <>
+    <widgets.LocalErrors errors={instanceErrors} />
       <fields.EmbeddedInstanceRequired<aas.types.ISubmodelElement>
         label="Value"
         helpUrl={

--- a/src/components/instances/PropertyFields.generated.tsx
+++ b/src/components/instances/PropertyFields.generated.tsx
@@ -11,10 +11,15 @@
 
 import * as aas from "@aas-core-works/aas-core3.0rc02-typescript";
 import * as React from "react";
+import * as valtio from "valtio";
 
-import * as fields from '../fields';
-import * as help from './help.generated';
-import * as newinstancing from '../../newinstancing.generated';
+import * as enhancing from "../../enhancing.generated";
+import * as fields from "../fields";
+import * as help from "./help.generated";
+import * as model from "../../model";
+import * as newinstancing from "../../newinstancing.generated";
+import * as verification from "../../verification";
+import * as widgets from "../widgets";
 
 export function PropertyFields(
   props: {
@@ -22,8 +27,98 @@ export function PropertyFields(
     instance: aas.types.Property,
   }
 ) {
+  const [instanceErrors, setInstanceErrors] = React.useState<
+    Array<enhancing.TimestampedError> | null>(null);
+
+  const [errorsForCategory, setErrorsForCategory] = React.useState<
+    Array<enhancing.TimestampedError> | null>(null);
+
+  const [errorsForIdShort, setErrorsForIdShort] = React.useState<
+    Array<enhancing.TimestampedError> | null>(null);
+
+  const [errorsForChecksum, setErrorsForChecksum] = React.useState<
+    Array<enhancing.TimestampedError> | null>(null);
+
+  const [errorsForKind, setErrorsForKind] = React.useState<
+    Array<enhancing.TimestampedError> | null>(null);
+
+  const [errorsForValueType, setErrorsForValueType] = React.useState<
+    Array<enhancing.TimestampedError> | null>(null);
+
+  const [errorsForValue, setErrorsForValue] = React.useState<
+    Array<enhancing.TimestampedError> | null>(null);
+
+  const snapErrorSetVersioning = valtio.useSnapshot(
+    model.getErrorSet(props.instance).versioning
+  );
+
+  React.useEffect(
+    () => {
+      const [
+        anotherInstanceErrors,
+        errorsByProperty
+      ] = verification.categorizeInstanceErrors(
+        model.getErrorSet(props.instance)
+      );
+
+      setInstanceErrors(anotherInstanceErrors);
+
+      const anotherErrorsForCategory =
+        errorsByProperty.get("category");
+      setErrorsForCategory(
+        anotherErrorsForCategory === undefined
+          ? null
+          : anotherErrorsForCategory
+      );
+
+      const anotherErrorsForIdShort =
+        errorsByProperty.get("idShort");
+      setErrorsForIdShort(
+        anotherErrorsForIdShort === undefined
+          ? null
+          : anotherErrorsForIdShort
+      );
+
+      const anotherErrorsForChecksum =
+        errorsByProperty.get("checksum");
+      setErrorsForChecksum(
+        anotherErrorsForChecksum === undefined
+          ? null
+          : anotherErrorsForChecksum
+      );
+
+      const anotherErrorsForKind =
+        errorsByProperty.get("kind");
+      setErrorsForKind(
+        anotherErrorsForKind === undefined
+          ? null
+          : anotherErrorsForKind
+      );
+
+      const anotherErrorsForValueType =
+        errorsByProperty.get("valueType");
+      setErrorsForValueType(
+        anotherErrorsForValueType === undefined
+          ? null
+          : anotherErrorsForValueType
+      );
+
+      const anotherErrorsForValue =
+        errorsByProperty.get("value");
+      setErrorsForValue(
+        anotherErrorsForValue === undefined
+          ? null
+          : anotherErrorsForValue
+      );
+    },
+    [
+      snapErrorSetVersioning,
+      props.instance
+    ]
+  );
   return (
     <>
+    <widgets.LocalErrors errors={instanceErrors} />
       <fields.ListFieldOptional<aas.types.Extension>
         label="Extensions"
         helpUrl={
@@ -58,6 +153,7 @@ export function PropertyFields(
             props.instance.category = value;
           }
         }
+        errors={errorsForCategory}
       />
 
       <fields.TextFieldOptional
@@ -71,6 +167,7 @@ export function PropertyFields(
             props.instance.idShort = value;
           }
         }
+        errors={errorsForIdShort}
       />
 
       <fields.ListFieldOptional<aas.types.LangString>
@@ -130,6 +227,7 @@ export function PropertyFields(
             props.instance.checksum = value;
           }
         }
+        errors={errorsForChecksum}
       />
 
       <fields.EnumerationFieldOptional
@@ -145,6 +243,7 @@ export function PropertyFields(
             props.instance.kind = value;
           }
         }
+        errors={errorsForKind}
       />
 
       <fields.EmbeddedInstanceOptional<aas.types.Reference>
@@ -252,6 +351,7 @@ export function PropertyFields(
             props.instance.valueType = value;
           }
         }
+        errors={errorsForValueType}
       />
 
       <fields.TextFieldOptional
@@ -265,6 +365,7 @@ export function PropertyFields(
             props.instance.value = value;
           }
         }
+        errors={errorsForValue}
       />
 
       <fields.EmbeddedInstanceOptional<aas.types.Reference>

--- a/src/components/instances/QualifierFields.generated.tsx
+++ b/src/components/instances/QualifierFields.generated.tsx
@@ -11,10 +11,15 @@
 
 import * as aas from "@aas-core-works/aas-core3.0rc02-typescript";
 import * as React from "react";
+import * as valtio from "valtio";
 
-import * as fields from '../fields';
-import * as help from './help.generated';
-import * as newinstancing from '../../newinstancing.generated';
+import * as enhancing from "../../enhancing.generated";
+import * as fields from "../fields";
+import * as help from "./help.generated";
+import * as model from "../../model";
+import * as newinstancing from "../../newinstancing.generated";
+import * as verification from "../../verification";
+import * as widgets from "../widgets";
 
 export function QualifierFields(
   props: {
@@ -22,8 +27,76 @@ export function QualifierFields(
     instance: aas.types.Qualifier,
   }
 ) {
+  const [instanceErrors, setInstanceErrors] = React.useState<
+    Array<enhancing.TimestampedError> | null>(null);
+
+  const [errorsForKind, setErrorsForKind] = React.useState<
+    Array<enhancing.TimestampedError> | null>(null);
+
+  const [errorsForType, setErrorsForType] = React.useState<
+    Array<enhancing.TimestampedError> | null>(null);
+
+  const [errorsForValueType, setErrorsForValueType] = React.useState<
+    Array<enhancing.TimestampedError> | null>(null);
+
+  const [errorsForValue, setErrorsForValue] = React.useState<
+    Array<enhancing.TimestampedError> | null>(null);
+
+  const snapErrorSetVersioning = valtio.useSnapshot(
+    model.getErrorSet(props.instance).versioning
+  );
+
+  React.useEffect(
+    () => {
+      const [
+        anotherInstanceErrors,
+        errorsByProperty
+      ] = verification.categorizeInstanceErrors(
+        model.getErrorSet(props.instance)
+      );
+
+      setInstanceErrors(anotherInstanceErrors);
+
+      const anotherErrorsForKind =
+        errorsByProperty.get("kind");
+      setErrorsForKind(
+        anotherErrorsForKind === undefined
+          ? null
+          : anotherErrorsForKind
+      );
+
+      const anotherErrorsForType =
+        errorsByProperty.get("type");
+      setErrorsForType(
+        anotherErrorsForType === undefined
+          ? null
+          : anotherErrorsForType
+      );
+
+      const anotherErrorsForValueType =
+        errorsByProperty.get("valueType");
+      setErrorsForValueType(
+        anotherErrorsForValueType === undefined
+          ? null
+          : anotherErrorsForValueType
+      );
+
+      const anotherErrorsForValue =
+        errorsByProperty.get("value");
+      setErrorsForValue(
+        anotherErrorsForValue === undefined
+          ? null
+          : anotherErrorsForValue
+      );
+    },
+    [
+      snapErrorSetVersioning,
+      props.instance
+    ]
+  );
   return (
     <>
+    <widgets.LocalErrors errors={instanceErrors} />
       <fields.EmbeddedInstanceOptional<aas.types.Reference>
         label="Semantic id"
         helpUrl={
@@ -83,6 +156,7 @@ export function QualifierFields(
             props.instance.kind = value;
           }
         }
+        errors={errorsForKind}
       />
 
       <fields.TextFieldRequired
@@ -96,6 +170,7 @@ export function QualifierFields(
             props.instance.type = value;
           }
         }
+        errors={errorsForType}
       />
 
       <fields.EnumerationFieldRequired
@@ -111,6 +186,7 @@ export function QualifierFields(
             props.instance.valueType = value;
           }
         }
+        errors={errorsForValueType}
       />
 
       <fields.TextFieldOptional
@@ -124,6 +200,7 @@ export function QualifierFields(
             props.instance.value = value;
           }
         }
+        errors={errorsForValue}
       />
 
       <fields.EmbeddedInstanceOptional<aas.types.Reference>

--- a/src/components/instances/RangeFields.generated.tsx
+++ b/src/components/instances/RangeFields.generated.tsx
@@ -11,10 +11,15 @@
 
 import * as aas from "@aas-core-works/aas-core3.0rc02-typescript";
 import * as React from "react";
+import * as valtio from "valtio";
 
-import * as fields from '../fields';
-import * as help from './help.generated';
-import * as newinstancing from '../../newinstancing.generated';
+import * as enhancing from "../../enhancing.generated";
+import * as fields from "../fields";
+import * as help from "./help.generated";
+import * as model from "../../model";
+import * as newinstancing from "../../newinstancing.generated";
+import * as verification from "../../verification";
+import * as widgets from "../widgets";
 
 export function RangeFields(
   props: {
@@ -22,8 +27,109 @@ export function RangeFields(
     instance: aas.types.Range,
   }
 ) {
+  const [instanceErrors, setInstanceErrors] = React.useState<
+    Array<enhancing.TimestampedError> | null>(null);
+
+  const [errorsForCategory, setErrorsForCategory] = React.useState<
+    Array<enhancing.TimestampedError> | null>(null);
+
+  const [errorsForIdShort, setErrorsForIdShort] = React.useState<
+    Array<enhancing.TimestampedError> | null>(null);
+
+  const [errorsForChecksum, setErrorsForChecksum] = React.useState<
+    Array<enhancing.TimestampedError> | null>(null);
+
+  const [errorsForKind, setErrorsForKind] = React.useState<
+    Array<enhancing.TimestampedError> | null>(null);
+
+  const [errorsForValueType, setErrorsForValueType] = React.useState<
+    Array<enhancing.TimestampedError> | null>(null);
+
+  const [errorsForMin, setErrorsForMin] = React.useState<
+    Array<enhancing.TimestampedError> | null>(null);
+
+  const [errorsForMax, setErrorsForMax] = React.useState<
+    Array<enhancing.TimestampedError> | null>(null);
+
+  const snapErrorSetVersioning = valtio.useSnapshot(
+    model.getErrorSet(props.instance).versioning
+  );
+
+  React.useEffect(
+    () => {
+      const [
+        anotherInstanceErrors,
+        errorsByProperty
+      ] = verification.categorizeInstanceErrors(
+        model.getErrorSet(props.instance)
+      );
+
+      setInstanceErrors(anotherInstanceErrors);
+
+      const anotherErrorsForCategory =
+        errorsByProperty.get("category");
+      setErrorsForCategory(
+        anotherErrorsForCategory === undefined
+          ? null
+          : anotherErrorsForCategory
+      );
+
+      const anotherErrorsForIdShort =
+        errorsByProperty.get("idShort");
+      setErrorsForIdShort(
+        anotherErrorsForIdShort === undefined
+          ? null
+          : anotherErrorsForIdShort
+      );
+
+      const anotherErrorsForChecksum =
+        errorsByProperty.get("checksum");
+      setErrorsForChecksum(
+        anotherErrorsForChecksum === undefined
+          ? null
+          : anotherErrorsForChecksum
+      );
+
+      const anotherErrorsForKind =
+        errorsByProperty.get("kind");
+      setErrorsForKind(
+        anotherErrorsForKind === undefined
+          ? null
+          : anotherErrorsForKind
+      );
+
+      const anotherErrorsForValueType =
+        errorsByProperty.get("valueType");
+      setErrorsForValueType(
+        anotherErrorsForValueType === undefined
+          ? null
+          : anotherErrorsForValueType
+      );
+
+      const anotherErrorsForMin =
+        errorsByProperty.get("min");
+      setErrorsForMin(
+        anotherErrorsForMin === undefined
+          ? null
+          : anotherErrorsForMin
+      );
+
+      const anotherErrorsForMax =
+        errorsByProperty.get("max");
+      setErrorsForMax(
+        anotherErrorsForMax === undefined
+          ? null
+          : anotherErrorsForMax
+      );
+    },
+    [
+      snapErrorSetVersioning,
+      props.instance
+    ]
+  );
   return (
     <>
+    <widgets.LocalErrors errors={instanceErrors} />
       <fields.ListFieldOptional<aas.types.Extension>
         label="Extensions"
         helpUrl={
@@ -58,6 +164,7 @@ export function RangeFields(
             props.instance.category = value;
           }
         }
+        errors={errorsForCategory}
       />
 
       <fields.TextFieldOptional
@@ -71,6 +178,7 @@ export function RangeFields(
             props.instance.idShort = value;
           }
         }
+        errors={errorsForIdShort}
       />
 
       <fields.ListFieldOptional<aas.types.LangString>
@@ -130,6 +238,7 @@ export function RangeFields(
             props.instance.checksum = value;
           }
         }
+        errors={errorsForChecksum}
       />
 
       <fields.EnumerationFieldOptional
@@ -145,6 +254,7 @@ export function RangeFields(
             props.instance.kind = value;
           }
         }
+        errors={errorsForKind}
       />
 
       <fields.EmbeddedInstanceOptional<aas.types.Reference>
@@ -252,6 +362,7 @@ export function RangeFields(
             props.instance.valueType = value;
           }
         }
+        errors={errorsForValueType}
       />
 
       <fields.TextFieldOptional
@@ -265,6 +376,7 @@ export function RangeFields(
             props.instance.min = value;
           }
         }
+        errors={errorsForMin}
       />
 
       <fields.TextFieldOptional
@@ -278,6 +390,7 @@ export function RangeFields(
             props.instance.max = value;
           }
         }
+        errors={errorsForMax}
       />
     </>
   )

--- a/src/components/instances/ReferenceElementFields.generated.tsx
+++ b/src/components/instances/ReferenceElementFields.generated.tsx
@@ -11,10 +11,15 @@
 
 import * as aas from "@aas-core-works/aas-core3.0rc02-typescript";
 import * as React from "react";
+import * as valtio from "valtio";
 
-import * as fields from '../fields';
-import * as help from './help.generated';
-import * as newinstancing from '../../newinstancing.generated';
+import * as enhancing from "../../enhancing.generated";
+import * as fields from "../fields";
+import * as help from "./help.generated";
+import * as model from "../../model";
+import * as newinstancing from "../../newinstancing.generated";
+import * as verification from "../../verification";
+import * as widgets from "../widgets";
 
 export function ReferenceElementFields(
   props: {
@@ -22,8 +27,76 @@ export function ReferenceElementFields(
     instance: aas.types.ReferenceElement,
   }
 ) {
+  const [instanceErrors, setInstanceErrors] = React.useState<
+    Array<enhancing.TimestampedError> | null>(null);
+
+  const [errorsForCategory, setErrorsForCategory] = React.useState<
+    Array<enhancing.TimestampedError> | null>(null);
+
+  const [errorsForIdShort, setErrorsForIdShort] = React.useState<
+    Array<enhancing.TimestampedError> | null>(null);
+
+  const [errorsForChecksum, setErrorsForChecksum] = React.useState<
+    Array<enhancing.TimestampedError> | null>(null);
+
+  const [errorsForKind, setErrorsForKind] = React.useState<
+    Array<enhancing.TimestampedError> | null>(null);
+
+  const snapErrorSetVersioning = valtio.useSnapshot(
+    model.getErrorSet(props.instance).versioning
+  );
+
+  React.useEffect(
+    () => {
+      const [
+        anotherInstanceErrors,
+        errorsByProperty
+      ] = verification.categorizeInstanceErrors(
+        model.getErrorSet(props.instance)
+      );
+
+      setInstanceErrors(anotherInstanceErrors);
+
+      const anotherErrorsForCategory =
+        errorsByProperty.get("category");
+      setErrorsForCategory(
+        anotherErrorsForCategory === undefined
+          ? null
+          : anotherErrorsForCategory
+      );
+
+      const anotherErrorsForIdShort =
+        errorsByProperty.get("idShort");
+      setErrorsForIdShort(
+        anotherErrorsForIdShort === undefined
+          ? null
+          : anotherErrorsForIdShort
+      );
+
+      const anotherErrorsForChecksum =
+        errorsByProperty.get("checksum");
+      setErrorsForChecksum(
+        anotherErrorsForChecksum === undefined
+          ? null
+          : anotherErrorsForChecksum
+      );
+
+      const anotherErrorsForKind =
+        errorsByProperty.get("kind");
+      setErrorsForKind(
+        anotherErrorsForKind === undefined
+          ? null
+          : anotherErrorsForKind
+      );
+    },
+    [
+      snapErrorSetVersioning,
+      props.instance
+    ]
+  );
   return (
     <>
+    <widgets.LocalErrors errors={instanceErrors} />
       <fields.ListFieldOptional<aas.types.Extension>
         label="Extensions"
         helpUrl={
@@ -58,6 +131,7 @@ export function ReferenceElementFields(
             props.instance.category = value;
           }
         }
+        errors={errorsForCategory}
       />
 
       <fields.TextFieldOptional
@@ -71,6 +145,7 @@ export function ReferenceElementFields(
             props.instance.idShort = value;
           }
         }
+        errors={errorsForIdShort}
       />
 
       <fields.ListFieldOptional<aas.types.LangString>
@@ -130,6 +205,7 @@ export function ReferenceElementFields(
             props.instance.checksum = value;
           }
         }
+        errors={errorsForChecksum}
       />
 
       <fields.EnumerationFieldOptional
@@ -145,6 +221,7 @@ export function ReferenceElementFields(
             props.instance.kind = value;
           }
         }
+        errors={errorsForKind}
       />
 
       <fields.EmbeddedInstanceOptional<aas.types.Reference>

--- a/src/components/instances/ReferenceFields.generated.tsx
+++ b/src/components/instances/ReferenceFields.generated.tsx
@@ -11,10 +11,15 @@
 
 import * as aas from "@aas-core-works/aas-core3.0rc02-typescript";
 import * as React from "react";
+import * as valtio from "valtio";
 
-import * as fields from '../fields';
-import * as help from './help.generated';
-import * as newinstancing from '../../newinstancing.generated';
+import * as enhancing from "../../enhancing.generated";
+import * as fields from "../fields";
+import * as help from "./help.generated";
+import * as model from "../../model";
+import * as newinstancing from "../../newinstancing.generated";
+import * as verification from "../../verification";
+import * as widgets from "../widgets";
 
 export function ReferenceFields(
   props: {
@@ -22,8 +27,43 @@ export function ReferenceFields(
     instance: aas.types.Reference,
   }
 ) {
+  const [instanceErrors, setInstanceErrors] = React.useState<
+    Array<enhancing.TimestampedError> | null>(null);
+
+  const [errorsForType, setErrorsForType] = React.useState<
+    Array<enhancing.TimestampedError> | null>(null);
+
+  const snapErrorSetVersioning = valtio.useSnapshot(
+    model.getErrorSet(props.instance).versioning
+  );
+
+  React.useEffect(
+    () => {
+      const [
+        anotherInstanceErrors,
+        errorsByProperty
+      ] = verification.categorizeInstanceErrors(
+        model.getErrorSet(props.instance)
+      );
+
+      setInstanceErrors(anotherInstanceErrors);
+
+      const anotherErrorsForType =
+        errorsByProperty.get("type");
+      setErrorsForType(
+        anotherErrorsForType === undefined
+          ? null
+          : anotherErrorsForType
+      );
+    },
+    [
+      snapErrorSetVersioning,
+      props.instance
+    ]
+  );
   return (
     <>
+    <widgets.LocalErrors errors={instanceErrors} />
       <fields.EnumerationFieldRequired
         label="Type"
         helpUrl={
@@ -37,6 +77,7 @@ export function ReferenceFields(
             props.instance.type = value;
           }
         }
+        errors={errorsForType}
       />
 
       <fields.EmbeddedInstanceOptional<aas.types.Reference>

--- a/src/components/instances/RelationshipElementFields.generated.tsx
+++ b/src/components/instances/RelationshipElementFields.generated.tsx
@@ -11,10 +11,15 @@
 
 import * as aas from "@aas-core-works/aas-core3.0rc02-typescript";
 import * as React from "react";
+import * as valtio from "valtio";
 
-import * as fields from '../fields';
-import * as help from './help.generated';
-import * as newinstancing from '../../newinstancing.generated';
+import * as enhancing from "../../enhancing.generated";
+import * as fields from "../fields";
+import * as help from "./help.generated";
+import * as model from "../../model";
+import * as newinstancing from "../../newinstancing.generated";
+import * as verification from "../../verification";
+import * as widgets from "../widgets";
 
 export function RelationshipElementFields(
   props: {
@@ -22,8 +27,76 @@ export function RelationshipElementFields(
     instance: aas.types.RelationshipElement,
   }
 ) {
+  const [instanceErrors, setInstanceErrors] = React.useState<
+    Array<enhancing.TimestampedError> | null>(null);
+
+  const [errorsForCategory, setErrorsForCategory] = React.useState<
+    Array<enhancing.TimestampedError> | null>(null);
+
+  const [errorsForIdShort, setErrorsForIdShort] = React.useState<
+    Array<enhancing.TimestampedError> | null>(null);
+
+  const [errorsForChecksum, setErrorsForChecksum] = React.useState<
+    Array<enhancing.TimestampedError> | null>(null);
+
+  const [errorsForKind, setErrorsForKind] = React.useState<
+    Array<enhancing.TimestampedError> | null>(null);
+
+  const snapErrorSetVersioning = valtio.useSnapshot(
+    model.getErrorSet(props.instance).versioning
+  );
+
+  React.useEffect(
+    () => {
+      const [
+        anotherInstanceErrors,
+        errorsByProperty
+      ] = verification.categorizeInstanceErrors(
+        model.getErrorSet(props.instance)
+      );
+
+      setInstanceErrors(anotherInstanceErrors);
+
+      const anotherErrorsForCategory =
+        errorsByProperty.get("category");
+      setErrorsForCategory(
+        anotherErrorsForCategory === undefined
+          ? null
+          : anotherErrorsForCategory
+      );
+
+      const anotherErrorsForIdShort =
+        errorsByProperty.get("idShort");
+      setErrorsForIdShort(
+        anotherErrorsForIdShort === undefined
+          ? null
+          : anotherErrorsForIdShort
+      );
+
+      const anotherErrorsForChecksum =
+        errorsByProperty.get("checksum");
+      setErrorsForChecksum(
+        anotherErrorsForChecksum === undefined
+          ? null
+          : anotherErrorsForChecksum
+      );
+
+      const anotherErrorsForKind =
+        errorsByProperty.get("kind");
+      setErrorsForKind(
+        anotherErrorsForKind === undefined
+          ? null
+          : anotherErrorsForKind
+      );
+    },
+    [
+      snapErrorSetVersioning,
+      props.instance
+    ]
+  );
   return (
     <>
+    <widgets.LocalErrors errors={instanceErrors} />
       <fields.ListFieldOptional<aas.types.Extension>
         label="Extensions"
         helpUrl={
@@ -58,6 +131,7 @@ export function RelationshipElementFields(
             props.instance.category = value;
           }
         }
+        errors={errorsForCategory}
       />
 
       <fields.TextFieldOptional
@@ -71,6 +145,7 @@ export function RelationshipElementFields(
             props.instance.idShort = value;
           }
         }
+        errors={errorsForIdShort}
       />
 
       <fields.ListFieldOptional<aas.types.LangString>
@@ -130,6 +205,7 @@ export function RelationshipElementFields(
             props.instance.checksum = value;
           }
         }
+        errors={errorsForChecksum}
       />
 
       <fields.EnumerationFieldOptional
@@ -145,6 +221,7 @@ export function RelationshipElementFields(
             props.instance.kind = value;
           }
         }
+        errors={errorsForKind}
       />
 
       <fields.EmbeddedInstanceOptional<aas.types.Reference>

--- a/src/components/instances/SpecificAssetIdFields.generated.tsx
+++ b/src/components/instances/SpecificAssetIdFields.generated.tsx
@@ -11,10 +11,15 @@
 
 import * as aas from "@aas-core-works/aas-core3.0rc02-typescript";
 import * as React from "react";
+import * as valtio from "valtio";
 
-import * as fields from '../fields';
-import * as help from './help.generated';
-import * as newinstancing from '../../newinstancing.generated';
+import * as enhancing from "../../enhancing.generated";
+import * as fields from "../fields";
+import * as help from "./help.generated";
+import * as model from "../../model";
+import * as newinstancing from "../../newinstancing.generated";
+import * as verification from "../../verification";
+import * as widgets from "../widgets";
 
 export function SpecificAssetIdFields(
   props: {
@@ -22,8 +27,54 @@ export function SpecificAssetIdFields(
     instance: aas.types.SpecificAssetId,
   }
 ) {
+  const [instanceErrors, setInstanceErrors] = React.useState<
+    Array<enhancing.TimestampedError> | null>(null);
+
+  const [errorsForName, setErrorsForName] = React.useState<
+    Array<enhancing.TimestampedError> | null>(null);
+
+  const [errorsForValue, setErrorsForValue] = React.useState<
+    Array<enhancing.TimestampedError> | null>(null);
+
+  const snapErrorSetVersioning = valtio.useSnapshot(
+    model.getErrorSet(props.instance).versioning
+  );
+
+  React.useEffect(
+    () => {
+      const [
+        anotherInstanceErrors,
+        errorsByProperty
+      ] = verification.categorizeInstanceErrors(
+        model.getErrorSet(props.instance)
+      );
+
+      setInstanceErrors(anotherInstanceErrors);
+
+      const anotherErrorsForName =
+        errorsByProperty.get("name");
+      setErrorsForName(
+        anotherErrorsForName === undefined
+          ? null
+          : anotherErrorsForName
+      );
+
+      const anotherErrorsForValue =
+        errorsByProperty.get("value");
+      setErrorsForValue(
+        anotherErrorsForValue === undefined
+          ? null
+          : anotherErrorsForValue
+      );
+    },
+    [
+      snapErrorSetVersioning,
+      props.instance
+    ]
+  );
   return (
     <>
+    <widgets.LocalErrors errors={instanceErrors} />
       <fields.EmbeddedInstanceOptional<aas.types.Reference>
         label="Semantic id"
         helpUrl={
@@ -81,6 +132,7 @@ export function SpecificAssetIdFields(
             props.instance.name = value;
           }
         }
+        errors={errorsForName}
       />
 
       <fields.TextFieldRequired
@@ -94,6 +146,7 @@ export function SpecificAssetIdFields(
             props.instance.value = value;
           }
         }
+        errors={errorsForValue}
       />
 
       <fields.EmbeddedInstanceRequired<aas.types.Reference>

--- a/src/components/instances/SubmodelElementCollectionFields.generated.tsx
+++ b/src/components/instances/SubmodelElementCollectionFields.generated.tsx
@@ -11,10 +11,15 @@
 
 import * as aas from "@aas-core-works/aas-core3.0rc02-typescript";
 import * as React from "react";
+import * as valtio from "valtio";
 
-import * as fields from '../fields';
-import * as help from './help.generated';
-import * as newinstancing from '../../newinstancing.generated';
+import * as enhancing from "../../enhancing.generated";
+import * as fields from "../fields";
+import * as help from "./help.generated";
+import * as model from "../../model";
+import * as newinstancing from "../../newinstancing.generated";
+import * as verification from "../../verification";
+import * as widgets from "../widgets";
 
 export function SubmodelElementCollectionFields(
   props: {
@@ -22,8 +27,76 @@ export function SubmodelElementCollectionFields(
     instance: aas.types.SubmodelElementCollection,
   }
 ) {
+  const [instanceErrors, setInstanceErrors] = React.useState<
+    Array<enhancing.TimestampedError> | null>(null);
+
+  const [errorsForCategory, setErrorsForCategory] = React.useState<
+    Array<enhancing.TimestampedError> | null>(null);
+
+  const [errorsForIdShort, setErrorsForIdShort] = React.useState<
+    Array<enhancing.TimestampedError> | null>(null);
+
+  const [errorsForChecksum, setErrorsForChecksum] = React.useState<
+    Array<enhancing.TimestampedError> | null>(null);
+
+  const [errorsForKind, setErrorsForKind] = React.useState<
+    Array<enhancing.TimestampedError> | null>(null);
+
+  const snapErrorSetVersioning = valtio.useSnapshot(
+    model.getErrorSet(props.instance).versioning
+  );
+
+  React.useEffect(
+    () => {
+      const [
+        anotherInstanceErrors,
+        errorsByProperty
+      ] = verification.categorizeInstanceErrors(
+        model.getErrorSet(props.instance)
+      );
+
+      setInstanceErrors(anotherInstanceErrors);
+
+      const anotherErrorsForCategory =
+        errorsByProperty.get("category");
+      setErrorsForCategory(
+        anotherErrorsForCategory === undefined
+          ? null
+          : anotherErrorsForCategory
+      );
+
+      const anotherErrorsForIdShort =
+        errorsByProperty.get("idShort");
+      setErrorsForIdShort(
+        anotherErrorsForIdShort === undefined
+          ? null
+          : anotherErrorsForIdShort
+      );
+
+      const anotherErrorsForChecksum =
+        errorsByProperty.get("checksum");
+      setErrorsForChecksum(
+        anotherErrorsForChecksum === undefined
+          ? null
+          : anotherErrorsForChecksum
+      );
+
+      const anotherErrorsForKind =
+        errorsByProperty.get("kind");
+      setErrorsForKind(
+        anotherErrorsForKind === undefined
+          ? null
+          : anotherErrorsForKind
+      );
+    },
+    [
+      snapErrorSetVersioning,
+      props.instance
+    ]
+  );
   return (
     <>
+    <widgets.LocalErrors errors={instanceErrors} />
       <fields.ListFieldOptional<aas.types.Extension>
         label="Extensions"
         helpUrl={
@@ -58,6 +131,7 @@ export function SubmodelElementCollectionFields(
             props.instance.category = value;
           }
         }
+        errors={errorsForCategory}
       />
 
       <fields.TextFieldOptional
@@ -71,6 +145,7 @@ export function SubmodelElementCollectionFields(
             props.instance.idShort = value;
           }
         }
+        errors={errorsForIdShort}
       />
 
       <fields.ListFieldOptional<aas.types.LangString>
@@ -130,6 +205,7 @@ export function SubmodelElementCollectionFields(
             props.instance.checksum = value;
           }
         }
+        errors={errorsForChecksum}
       />
 
       <fields.EnumerationFieldOptional
@@ -145,6 +221,7 @@ export function SubmodelElementCollectionFields(
             props.instance.kind = value;
           }
         }
+        errors={errorsForKind}
       />
 
       <fields.EmbeddedInstanceOptional<aas.types.Reference>

--- a/src/components/instances/SubmodelElementListFields.generated.tsx
+++ b/src/components/instances/SubmodelElementListFields.generated.tsx
@@ -11,10 +11,15 @@
 
 import * as aas from "@aas-core-works/aas-core3.0rc02-typescript";
 import * as React from "react";
+import * as valtio from "valtio";
 
-import * as fields from '../fields';
-import * as help from './help.generated';
-import * as newinstancing from '../../newinstancing.generated';
+import * as enhancing from "../../enhancing.generated";
+import * as fields from "../fields";
+import * as help from "./help.generated";
+import * as model from "../../model";
+import * as newinstancing from "../../newinstancing.generated";
+import * as verification from "../../verification";
+import * as widgets from "../widgets";
 
 export function SubmodelElementListFields(
   props: {
@@ -22,8 +27,109 @@ export function SubmodelElementListFields(
     instance: aas.types.SubmodelElementList,
   }
 ) {
+  const [instanceErrors, setInstanceErrors] = React.useState<
+    Array<enhancing.TimestampedError> | null>(null);
+
+  const [errorsForCategory, setErrorsForCategory] = React.useState<
+    Array<enhancing.TimestampedError> | null>(null);
+
+  const [errorsForIdShort, setErrorsForIdShort] = React.useState<
+    Array<enhancing.TimestampedError> | null>(null);
+
+  const [errorsForChecksum, setErrorsForChecksum] = React.useState<
+    Array<enhancing.TimestampedError> | null>(null);
+
+  const [errorsForKind, setErrorsForKind] = React.useState<
+    Array<enhancing.TimestampedError> | null>(null);
+
+  const [errorsForOrderRelevant, setErrorsForOrderRelevant] = React.useState<
+    Array<enhancing.TimestampedError> | null>(null);
+
+  const [errorsForTypeValueListElement, setErrorsForTypeValueListElement] = React.useState<
+    Array<enhancing.TimestampedError> | null>(null);
+
+  const [errorsForValueTypeListElement, setErrorsForValueTypeListElement] = React.useState<
+    Array<enhancing.TimestampedError> | null>(null);
+
+  const snapErrorSetVersioning = valtio.useSnapshot(
+    model.getErrorSet(props.instance).versioning
+  );
+
+  React.useEffect(
+    () => {
+      const [
+        anotherInstanceErrors,
+        errorsByProperty
+      ] = verification.categorizeInstanceErrors(
+        model.getErrorSet(props.instance)
+      );
+
+      setInstanceErrors(anotherInstanceErrors);
+
+      const anotherErrorsForCategory =
+        errorsByProperty.get("category");
+      setErrorsForCategory(
+        anotherErrorsForCategory === undefined
+          ? null
+          : anotherErrorsForCategory
+      );
+
+      const anotherErrorsForIdShort =
+        errorsByProperty.get("idShort");
+      setErrorsForIdShort(
+        anotherErrorsForIdShort === undefined
+          ? null
+          : anotherErrorsForIdShort
+      );
+
+      const anotherErrorsForChecksum =
+        errorsByProperty.get("checksum");
+      setErrorsForChecksum(
+        anotherErrorsForChecksum === undefined
+          ? null
+          : anotherErrorsForChecksum
+      );
+
+      const anotherErrorsForKind =
+        errorsByProperty.get("kind");
+      setErrorsForKind(
+        anotherErrorsForKind === undefined
+          ? null
+          : anotherErrorsForKind
+      );
+
+      const anotherErrorsForOrderRelevant =
+        errorsByProperty.get("orderRelevant");
+      setErrorsForOrderRelevant(
+        anotherErrorsForOrderRelevant === undefined
+          ? null
+          : anotherErrorsForOrderRelevant
+      );
+
+      const anotherErrorsForTypeValueListElement =
+        errorsByProperty.get("typeValueListElement");
+      setErrorsForTypeValueListElement(
+        anotherErrorsForTypeValueListElement === undefined
+          ? null
+          : anotherErrorsForTypeValueListElement
+      );
+
+      const anotherErrorsForValueTypeListElement =
+        errorsByProperty.get("valueTypeListElement");
+      setErrorsForValueTypeListElement(
+        anotherErrorsForValueTypeListElement === undefined
+          ? null
+          : anotherErrorsForValueTypeListElement
+      );
+    },
+    [
+      snapErrorSetVersioning,
+      props.instance
+    ]
+  );
   return (
     <>
+    <widgets.LocalErrors errors={instanceErrors} />
       <fields.ListFieldOptional<aas.types.Extension>
         label="Extensions"
         helpUrl={
@@ -58,6 +164,7 @@ export function SubmodelElementListFields(
             props.instance.category = value;
           }
         }
+        errors={errorsForCategory}
       />
 
       <fields.TextFieldOptional
@@ -71,6 +178,7 @@ export function SubmodelElementListFields(
             props.instance.idShort = value;
           }
         }
+        errors={errorsForIdShort}
       />
 
       <fields.ListFieldOptional<aas.types.LangString>
@@ -130,6 +238,7 @@ export function SubmodelElementListFields(
             props.instance.checksum = value;
           }
         }
+        errors={errorsForChecksum}
       />
 
       <fields.EnumerationFieldOptional
@@ -145,6 +254,7 @@ export function SubmodelElementListFields(
             props.instance.kind = value;
           }
         }
+        errors={errorsForKind}
       />
 
       <fields.EmbeddedInstanceOptional<aas.types.Reference>
@@ -250,6 +360,7 @@ export function SubmodelElementListFields(
             props.instance.orderRelevant = value;
           }
         }
+        errors={errorsForOrderRelevant}
       />
 
       <fields.ListFieldOptional<aas.types.ISubmodelElement>
@@ -311,6 +422,7 @@ export function SubmodelElementListFields(
             props.instance.typeValueListElement = value;
           }
         }
+        errors={errorsForTypeValueListElement}
       />
 
       <fields.EnumerationFieldOptional
@@ -326,6 +438,7 @@ export function SubmodelElementListFields(
             props.instance.valueTypeListElement = value;
           }
         }
+        errors={errorsForValueTypeListElement}
       />
     </>
   )

--- a/src/components/instances/SubmodelFields.generated.tsx
+++ b/src/components/instances/SubmodelFields.generated.tsx
@@ -11,10 +11,15 @@
 
 import * as aas from "@aas-core-works/aas-core3.0rc02-typescript";
 import * as React from "react";
+import * as valtio from "valtio";
 
-import * as fields from '../fields';
-import * as help from './help.generated';
-import * as newinstancing from '../../newinstancing.generated';
+import * as enhancing from "../../enhancing.generated";
+import * as fields from "../fields";
+import * as help from "./help.generated";
+import * as model from "../../model";
+import * as newinstancing from "../../newinstancing.generated";
+import * as verification from "../../verification";
+import * as widgets from "../widgets";
 
 export function SubmodelFields(
   props: {
@@ -22,8 +27,87 @@ export function SubmodelFields(
     instance: aas.types.Submodel,
   }
 ) {
+  const [instanceErrors, setInstanceErrors] = React.useState<
+    Array<enhancing.TimestampedError> | null>(null);
+
+  const [errorsForCategory, setErrorsForCategory] = React.useState<
+    Array<enhancing.TimestampedError> | null>(null);
+
+  const [errorsForIdShort, setErrorsForIdShort] = React.useState<
+    Array<enhancing.TimestampedError> | null>(null);
+
+  const [errorsForChecksum, setErrorsForChecksum] = React.useState<
+    Array<enhancing.TimestampedError> | null>(null);
+
+  const [errorsForId, setErrorsForId] = React.useState<
+    Array<enhancing.TimestampedError> | null>(null);
+
+  const [errorsForKind, setErrorsForKind] = React.useState<
+    Array<enhancing.TimestampedError> | null>(null);
+
+  const snapErrorSetVersioning = valtio.useSnapshot(
+    model.getErrorSet(props.instance).versioning
+  );
+
+  React.useEffect(
+    () => {
+      const [
+        anotherInstanceErrors,
+        errorsByProperty
+      ] = verification.categorizeInstanceErrors(
+        model.getErrorSet(props.instance)
+      );
+
+      setInstanceErrors(anotherInstanceErrors);
+
+      const anotherErrorsForCategory =
+        errorsByProperty.get("category");
+      setErrorsForCategory(
+        anotherErrorsForCategory === undefined
+          ? null
+          : anotherErrorsForCategory
+      );
+
+      const anotherErrorsForIdShort =
+        errorsByProperty.get("idShort");
+      setErrorsForIdShort(
+        anotherErrorsForIdShort === undefined
+          ? null
+          : anotherErrorsForIdShort
+      );
+
+      const anotherErrorsForChecksum =
+        errorsByProperty.get("checksum");
+      setErrorsForChecksum(
+        anotherErrorsForChecksum === undefined
+          ? null
+          : anotherErrorsForChecksum
+      );
+
+      const anotherErrorsForId =
+        errorsByProperty.get("id");
+      setErrorsForId(
+        anotherErrorsForId === undefined
+          ? null
+          : anotherErrorsForId
+      );
+
+      const anotherErrorsForKind =
+        errorsByProperty.get("kind");
+      setErrorsForKind(
+        anotherErrorsForKind === undefined
+          ? null
+          : anotherErrorsForKind
+      );
+    },
+    [
+      snapErrorSetVersioning,
+      props.instance
+    ]
+  );
   return (
     <>
+    <widgets.LocalErrors errors={instanceErrors} />
       <fields.ListFieldOptional<aas.types.Extension>
         label="Extensions"
         helpUrl={
@@ -58,6 +142,7 @@ export function SubmodelFields(
             props.instance.category = value;
           }
         }
+        errors={errorsForCategory}
       />
 
       <fields.TextFieldOptional
@@ -71,6 +156,7 @@ export function SubmodelFields(
             props.instance.idShort = value;
           }
         }
+        errors={errorsForIdShort}
       />
 
       <fields.ListFieldOptional<aas.types.LangString>
@@ -130,6 +216,7 @@ export function SubmodelFields(
             props.instance.checksum = value;
           }
         }
+        errors={errorsForChecksum}
       />
 
       <fields.EmbeddedInstanceOptional<aas.types.AdministrativeInformation>
@@ -166,6 +253,7 @@ export function SubmodelFields(
             props.instance.id = value;
           }
         }
+        errors={errorsForId}
       />
 
       <fields.EnumerationFieldOptional
@@ -181,6 +269,7 @@ export function SubmodelFields(
             props.instance.kind = value;
           }
         }
+        errors={errorsForKind}
       />
 
       <fields.EmbeddedInstanceOptional<aas.types.Reference>

--- a/src/components/instances/ValueListFields.generated.tsx
+++ b/src/components/instances/ValueListFields.generated.tsx
@@ -11,10 +11,15 @@
 
 import * as aas from "@aas-core-works/aas-core3.0rc02-typescript";
 import * as React from "react";
+import * as valtio from "valtio";
 
-import * as fields from '../fields';
-import * as help from './help.generated';
-import * as newinstancing from '../../newinstancing.generated';
+import * as enhancing from "../../enhancing.generated";
+import * as fields from "../fields";
+import * as help from "./help.generated";
+import * as model from "../../model";
+import * as newinstancing from "../../newinstancing.generated";
+import * as verification from "../../verification";
+import * as widgets from "../widgets";
 
 export function ValueListFields(
   props: {
@@ -22,8 +27,32 @@ export function ValueListFields(
     instance: aas.types.ValueList,
   }
 ) {
+  const [instanceErrors, setInstanceErrors] = React.useState<
+    Array<enhancing.TimestampedError> | null>(null);
+
+  const snapErrorSetVersioning = valtio.useSnapshot(
+    model.getErrorSet(props.instance).versioning
+  );
+
+  React.useEffect(
+    () => {
+      const [
+        anotherInstanceErrors,
+        _
+      ] = verification.categorizeInstanceErrors(
+        model.getErrorSet(props.instance)
+      );
+
+      setInstanceErrors(anotherInstanceErrors);
+    },
+    [
+      snapErrorSetVersioning,
+      props.instance
+    ]
+  );
   return (
     <>
+    <widgets.LocalErrors errors={instanceErrors} />
       <fields.ListFieldRequired<aas.types.ValueReferencePair>
         label="Value reference pairs"
         helpUrl={

--- a/src/components/instances/ValueReferencePairFields.generated.tsx
+++ b/src/components/instances/ValueReferencePairFields.generated.tsx
@@ -11,10 +11,15 @@
 
 import * as aas from "@aas-core-works/aas-core3.0rc02-typescript";
 import * as React from "react";
+import * as valtio from "valtio";
 
-import * as fields from '../fields';
-import * as help from './help.generated';
-import * as newinstancing from '../../newinstancing.generated';
+import * as enhancing from "../../enhancing.generated";
+import * as fields from "../fields";
+import * as help from "./help.generated";
+import * as model from "../../model";
+import * as newinstancing from "../../newinstancing.generated";
+import * as verification from "../../verification";
+import * as widgets from "../widgets";
 
 export function ValueReferencePairFields(
   props: {
@@ -22,8 +27,43 @@ export function ValueReferencePairFields(
     instance: aas.types.ValueReferencePair,
   }
 ) {
+  const [instanceErrors, setInstanceErrors] = React.useState<
+    Array<enhancing.TimestampedError> | null>(null);
+
+  const [errorsForValue, setErrorsForValue] = React.useState<
+    Array<enhancing.TimestampedError> | null>(null);
+
+  const snapErrorSetVersioning = valtio.useSnapshot(
+    model.getErrorSet(props.instance).versioning
+  );
+
+  React.useEffect(
+    () => {
+      const [
+        anotherInstanceErrors,
+        errorsByProperty
+      ] = verification.categorizeInstanceErrors(
+        model.getErrorSet(props.instance)
+      );
+
+      setInstanceErrors(anotherInstanceErrors);
+
+      const anotherErrorsForValue =
+        errorsByProperty.get("value");
+      setErrorsForValue(
+        anotherErrorsForValue === undefined
+          ? null
+          : anotherErrorsForValue
+      );
+    },
+    [
+      snapErrorSetVersioning,
+      props.instance
+    ]
+  );
   return (
     <>
+    <widgets.LocalErrors errors={instanceErrors} />
       <fields.TextFieldRequired
         label="Value"
         helpUrl={
@@ -35,6 +75,7 @@ export function ValueReferencePairFields(
             props.instance.value = value;
           }
         }
+        errors={errorsForValue}
       />
 
       <fields.EmbeddedInstanceRequired<aas.types.Reference>

--- a/src/components/instances/fielding.generated.ts
+++ b/src/components/instances/fielding.generated.ts
@@ -69,7 +69,7 @@ class FieldDispatcher extends aas.types.AbstractTransformerWithContext<
   ): React.ReactElement {
     assertTypesMatch(that, snap);
 
-    return ExtensionFields({
+    return React.createElement(ExtensionFields, {
       snapInstance: snap,
       instance: that,
     });
@@ -81,7 +81,7 @@ class FieldDispatcher extends aas.types.AbstractTransformerWithContext<
   ): React.ReactElement {
     assertTypesMatch(that, snap);
 
-    return AdministrativeInformationFields({
+    return React.createElement(AdministrativeInformationFields, {
       snapInstance: snap,
       instance: that,
     });
@@ -93,7 +93,7 @@ class FieldDispatcher extends aas.types.AbstractTransformerWithContext<
   ): React.ReactElement {
     assertTypesMatch(that, snap);
 
-    return QualifierFields({
+    return React.createElement(QualifierFields, {
       snapInstance: snap,
       instance: that,
     });
@@ -105,7 +105,7 @@ class FieldDispatcher extends aas.types.AbstractTransformerWithContext<
   ): React.ReactElement {
     assertTypesMatch(that, snap);
 
-    return AssetAdministrationShellFields({
+    return React.createElement(AssetAdministrationShellFields, {
       snapInstance: snap,
       instance: that,
     });
@@ -117,7 +117,7 @@ class FieldDispatcher extends aas.types.AbstractTransformerWithContext<
   ): React.ReactElement {
     assertTypesMatch(that, snap);
 
-    return AssetInformationFields({
+    return React.createElement(AssetInformationFields, {
       snapInstance: snap,
       instance: that,
     });
@@ -129,7 +129,7 @@ class FieldDispatcher extends aas.types.AbstractTransformerWithContext<
   ): React.ReactElement {
     assertTypesMatch(that, snap);
 
-    return ResourceFields({
+    return React.createElement(ResourceFields, {
       snapInstance: snap,
       instance: that,
     });
@@ -141,7 +141,7 @@ class FieldDispatcher extends aas.types.AbstractTransformerWithContext<
   ): React.ReactElement {
     assertTypesMatch(that, snap);
 
-    return SpecificAssetIdFields({
+    return React.createElement(SpecificAssetIdFields, {
       snapInstance: snap,
       instance: that,
     });
@@ -153,7 +153,7 @@ class FieldDispatcher extends aas.types.AbstractTransformerWithContext<
   ): React.ReactElement {
     assertTypesMatch(that, snap);
 
-    return SubmodelFields({
+    return React.createElement(SubmodelFields, {
       snapInstance: snap,
       instance: that,
     });
@@ -165,7 +165,7 @@ class FieldDispatcher extends aas.types.AbstractTransformerWithContext<
   ): React.ReactElement {
     assertTypesMatch(that, snap);
 
-    return RelationshipElementFields({
+    return React.createElement(RelationshipElementFields, {
       snapInstance: snap,
       instance: that,
     });
@@ -177,7 +177,7 @@ class FieldDispatcher extends aas.types.AbstractTransformerWithContext<
   ): React.ReactElement {
     assertTypesMatch(that, snap);
 
-    return SubmodelElementListFields({
+    return React.createElement(SubmodelElementListFields, {
       snapInstance: snap,
       instance: that,
     });
@@ -189,7 +189,7 @@ class FieldDispatcher extends aas.types.AbstractTransformerWithContext<
   ): React.ReactElement {
     assertTypesMatch(that, snap);
 
-    return SubmodelElementCollectionFields({
+    return React.createElement(SubmodelElementCollectionFields, {
       snapInstance: snap,
       instance: that,
     });
@@ -201,7 +201,7 @@ class FieldDispatcher extends aas.types.AbstractTransformerWithContext<
   ): React.ReactElement {
     assertTypesMatch(that, snap);
 
-    return PropertyFields({
+    return React.createElement(PropertyFields, {
       snapInstance: snap,
       instance: that,
     });
@@ -213,7 +213,7 @@ class FieldDispatcher extends aas.types.AbstractTransformerWithContext<
   ): React.ReactElement {
     assertTypesMatch(that, snap);
 
-    return MultiLanguagePropertyFields({
+    return React.createElement(MultiLanguagePropertyFields, {
       snapInstance: snap,
       instance: that,
     });
@@ -225,7 +225,7 @@ class FieldDispatcher extends aas.types.AbstractTransformerWithContext<
   ): React.ReactElement {
     assertTypesMatch(that, snap);
 
-    return RangeFields({
+    return React.createElement(RangeFields, {
       snapInstance: snap,
       instance: that,
     });
@@ -237,7 +237,7 @@ class FieldDispatcher extends aas.types.AbstractTransformerWithContext<
   ): React.ReactElement {
     assertTypesMatch(that, snap);
 
-    return ReferenceElementFields({
+    return React.createElement(ReferenceElementFields, {
       snapInstance: snap,
       instance: that,
     });
@@ -249,7 +249,7 @@ class FieldDispatcher extends aas.types.AbstractTransformerWithContext<
   ): React.ReactElement {
     assertTypesMatch(that, snap);
 
-    return BlobFields({
+    return React.createElement(BlobFields, {
       snapInstance: snap,
       instance: that,
     });
@@ -261,7 +261,7 @@ class FieldDispatcher extends aas.types.AbstractTransformerWithContext<
   ): React.ReactElement {
     assertTypesMatch(that, snap);
 
-    return FileFields({
+    return React.createElement(FileFields, {
       snapInstance: snap,
       instance: that,
     });
@@ -273,7 +273,7 @@ class FieldDispatcher extends aas.types.AbstractTransformerWithContext<
   ): React.ReactElement {
     assertTypesMatch(that, snap);
 
-    return AnnotatedRelationshipElementFields({
+    return React.createElement(AnnotatedRelationshipElementFields, {
       snapInstance: snap,
       instance: that,
     });
@@ -285,7 +285,7 @@ class FieldDispatcher extends aas.types.AbstractTransformerWithContext<
   ): React.ReactElement {
     assertTypesMatch(that, snap);
 
-    return EntityFields({
+    return React.createElement(EntityFields, {
       snapInstance: snap,
       instance: that,
     });
@@ -297,7 +297,7 @@ class FieldDispatcher extends aas.types.AbstractTransformerWithContext<
   ): React.ReactElement {
     assertTypesMatch(that, snap);
 
-    return EventPayloadFields({
+    return React.createElement(EventPayloadFields, {
       snapInstance: snap,
       instance: that,
     });
@@ -309,7 +309,7 @@ class FieldDispatcher extends aas.types.AbstractTransformerWithContext<
   ): React.ReactElement {
     assertTypesMatch(that, snap);
 
-    return BasicEventElementFields({
+    return React.createElement(BasicEventElementFields, {
       snapInstance: snap,
       instance: that,
     });
@@ -321,7 +321,7 @@ class FieldDispatcher extends aas.types.AbstractTransformerWithContext<
   ): React.ReactElement {
     assertTypesMatch(that, snap);
 
-    return OperationFields({
+    return React.createElement(OperationFields, {
       snapInstance: snap,
       instance: that,
     });
@@ -333,7 +333,7 @@ class FieldDispatcher extends aas.types.AbstractTransformerWithContext<
   ): React.ReactElement {
     assertTypesMatch(that, snap);
 
-    return OperationVariableFields({
+    return React.createElement(OperationVariableFields, {
       snapInstance: snap,
       instance: that,
     });
@@ -345,7 +345,7 @@ class FieldDispatcher extends aas.types.AbstractTransformerWithContext<
   ): React.ReactElement {
     assertTypesMatch(that, snap);
 
-    return CapabilityFields({
+    return React.createElement(CapabilityFields, {
       snapInstance: snap,
       instance: that,
     });
@@ -357,7 +357,7 @@ class FieldDispatcher extends aas.types.AbstractTransformerWithContext<
   ): React.ReactElement {
     assertTypesMatch(that, snap);
 
-    return ConceptDescriptionFields({
+    return React.createElement(ConceptDescriptionFields, {
       snapInstance: snap,
       instance: that,
     });
@@ -369,7 +369,7 @@ class FieldDispatcher extends aas.types.AbstractTransformerWithContext<
   ): React.ReactElement {
     assertTypesMatch(that, snap);
 
-    return ReferenceFields({
+    return React.createElement(ReferenceFields, {
       snapInstance: snap,
       instance: that,
     });
@@ -381,7 +381,7 @@ class FieldDispatcher extends aas.types.AbstractTransformerWithContext<
   ): React.ReactElement {
     assertTypesMatch(that, snap);
 
-    return KeyFields({
+    return React.createElement(KeyFields, {
       snapInstance: snap,
       instance: that,
     });
@@ -393,7 +393,7 @@ class FieldDispatcher extends aas.types.AbstractTransformerWithContext<
   ): React.ReactElement {
     assertTypesMatch(that, snap);
 
-    return LangStringFields({
+    return React.createElement(LangStringFields, {
       snapInstance: snap,
       instance: that,
     });
@@ -405,7 +405,7 @@ class FieldDispatcher extends aas.types.AbstractTransformerWithContext<
   ): React.ReactElement {
     assertTypesMatch(that, snap);
 
-    return EnvironmentFields({
+    return React.createElement(EnvironmentFields, {
       snapInstance: snap,
       instance: that,
     });
@@ -417,7 +417,7 @@ class FieldDispatcher extends aas.types.AbstractTransformerWithContext<
   ): React.ReactElement {
     assertTypesMatch(that, snap);
 
-    return EmbeddedDataSpecificationFields({
+    return React.createElement(EmbeddedDataSpecificationFields, {
       snapInstance: snap,
       instance: that,
     });
@@ -429,7 +429,7 @@ class FieldDispatcher extends aas.types.AbstractTransformerWithContext<
   ): React.ReactElement {
     assertTypesMatch(that, snap);
 
-    return ValueReferencePairFields({
+    return React.createElement(ValueReferencePairFields, {
       snapInstance: snap,
       instance: that,
     });
@@ -441,7 +441,7 @@ class FieldDispatcher extends aas.types.AbstractTransformerWithContext<
   ): React.ReactElement {
     assertTypesMatch(that, snap);
 
-    return ValueListFields({
+    return React.createElement(ValueListFields, {
       snapInstance: snap,
       instance: that,
     });
@@ -453,7 +453,7 @@ class FieldDispatcher extends aas.types.AbstractTransformerWithContext<
   ): React.ReactElement {
     assertTypesMatch(that, snap);
 
-    return DataSpecificationIec61360Fields({
+    return React.createElement(DataSpecificationIec61360Fields, {
       snapInstance: snap,
       instance: that,
     });
@@ -465,7 +465,7 @@ class FieldDispatcher extends aas.types.AbstractTransformerWithContext<
   ): React.ReactElement {
     assertTypesMatch(that, snap);
 
-    return DataSpecificationPhysicalUnitFields({
+    return React.createElement(DataSpecificationPhysicalUnitFields, {
       snapInstance: snap,
       instance: that,
     });

--- a/src/components/widgets/LocalErrors.tsx
+++ b/src/components/widgets/LocalErrors.tsx
@@ -1,0 +1,31 @@
+import * as React from "react";
+
+import * as enhancing from "../../enhancing.generated";
+
+
+export function LocalErrors(
+  props: {
+    errors: Array<enhancing.TimestampedError> | null
+  }
+) {
+  if (props.errors === null || props.errors.length === 0) {
+    return (<></>);
+  }
+
+  return (
+    <div className="aas-errors">
+      <ul>
+        {
+          props.errors?.map((error) => {
+              return (
+                <li key={error.guid}>
+                  <span className="aas-error-message">{error.message}</span>
+                </li>
+              );
+            }
+          )
+        }
+      </ul>
+    </div>
+  );
+}

--- a/src/components/widgets/TextAreaAutoResized.tsx
+++ b/src/components/widgets/TextAreaAutoResized.tsx
@@ -1,7 +1,6 @@
 import * as React from "react";
 
 export function TextAreaAutoResized(props: {
-  id: string,
   content: string,
   onChange: (content: string) => void
 }) {
@@ -37,7 +36,6 @@ export function TextAreaAutoResized(props: {
       rows={1}
       style={{resize: "none", minHeight: "1.1em"}}
       ref={textAreaRef}
-      id={props.id}
       value={props.content}
       onChange={
         (event) => {

--- a/src/components/widgets/index.ts
+++ b/src/components/widgets/index.ts
@@ -1,4 +1,5 @@
 export { BytesContainer } from "./BytesContainer";
+export { LocalErrors } from "./LocalErrors";
 export { OkScreen } from "./OkScreen";
 export { OkCancelScreen } from "./OkCancelScreen";
 export { SplashScreen } from "./SplashScreen";

--- a/src/enhancing.generated.ts
+++ b/src/enhancing.generated.ts
@@ -54,46 +54,71 @@ export class TimestampedError {
 
     return result;
   }
+
+  relativePathFromInstanceAsString(): string {
+    if (this.relativePathFromInstance.length === 0) {
+      return "";
+    }
+
+    // NOTE (2023-02-10):
+    // See: https://stackoverflow.com/questions/16696632/most-efficient-way-to-concatenate-strings-in-javascript
+    // for string concatenation.
+    let result = "";
+
+    for (const segment of this.relativePathFromInstance) {
+      if (typeof segment === "string") {
+        result += `.${segment}`;
+      } else {
+        result += `[${segment}]`;
+      }
+    }
+
+    return result;
+  }
 }
 
 export class VersionedSet<T> {
-  private readonly content = new Set<T>();
-  private readonly versioning = valtio.proxy({ version: 0 });
+  private readonly _content = new Set<T>();
+  private readonly _versioning = valtio.proxy({ version: 0 });
 
   *[Symbol.iterator]() {
-    yield* this.content;
+    yield* this._content;
   }
 
   add(item: T) {
     let bumpVersion = false;
-    if (!this.content.has(item)) {
-      this.content.add(item);
+    if (!this._content.has(item)) {
+      this._content.add(item);
       bumpVersion = true;
     }
 
     if (bumpVersion) {
-      this.versioning.version++;
+      this._versioning.version++;
     }
   }
 
   delete(item: T) {
-    const bumpVersion = this.content.delete(item);
+    const bumpVersion = this._content.delete(item);
     if (bumpVersion) {
-      this.versioning.version++;
+      this._versioning.version++;
     }
   }
 
   clear() {
-    if (this.content.size === 0) {
+    if (this._content.size === 0) {
       return;
     }
 
-    this.content.clear();
-    this.versioning.version++;
+    this._content.clear();
+    this._versioning.version++;
   }
 
   public get size() {
-    return this.content.size;
+    return this._content.size;
+  }
+
+  public get versioning() {
+    return this._versioning;
   }
 }
 


### PR DESCRIPTION
Hunting for errors in a large AAS files is tedious. Therefore we both show the errors in a list at the bottom for easier reference, and locally, at the property or the relevant instance.